### PR TITLE
feat(mail): SQLite row-id message lookup for the five write commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,7 +235,7 @@ Durable memory promoted from `~/.claude/projects/-Users-omarshahine-GitHub-apple
 - Root `package.json` has shared deps (`mailparser`, `turndown`) for `lib/` resolution
 - Agent at `agents/pim-assistant.md`, skill at `skills/apple-pim/SKILL.md`
 - CalendarCLI and ReminderCLI share identical helper functions (ruleToDict, parseRecurrenceRule, etc) - changes to one must be mirrored in the other
-- MailCLI reads (accounts/mailboxes/messages/get/search) default to a direct read-only SQLite engine over Mail's Envelope Index (`EnvelopeIndex.swift`/`SQLiteEngine.swift`, needs Full Disk Access, works with Mail closed) with silent JXA fallback; mutations/sends and `content` search use JXA/AppleScript via `osascript -l JavaScript` — no native Swift framework for Mail.app
+- MailCLI reads (accounts/mailboxes/messages/get/search) default to a direct read-only SQLite engine over Mail's Envelope Index (`EnvelopeIndex.swift`/`SQLiteEngine.swift`, needs Full Disk Access, works with Mail closed) with silent JXA fallback; mutations/sends and `content` search use JXA/AppleScript via `osascript -l JavaScript` — no native Swift framework for Mail.app. The five mutation commands (update/move/delete/batch-update/batch-delete) also take `--engine`: under `auto` they read the same index to look a message up by row-id before the JXA write, and fall back to the JXA mailbox scan when they cannot
 
 ## Key Patterns
 - `RecurrenceJSON.frequency` is `String?` (optional) — `nil` or `"none"` means remove recurrence

--- a/README.md
+++ b/README.md
@@ -451,7 +451,9 @@ mailbox, and they fall back to that scan whenever the lookup cannot answer.
   no `engine` key: `batch-update` and `batch-delete` report the locator built
   in `_lookup.backend` (`sqlite` once an index opens, `jxa-only` otherwise) and
   the hit/fallback counts in `_lookup.stats`; `update`, `move` and `delete`
-  carry a per-message `_lookup` inside `result` only under `MAIL_CLI_DEBUG=1`.
+  carry a per-message `_lookup` inside `result` only under `MAIL_CLI_DEBUG=1`,
+  with the same four counts in its `_lookup.stats` — one message per run, so
+  they are that lookup's own.
 
 ### Direct SMTP path (`mail-cli smtp-send`)
 

--- a/README.md
+++ b/README.md
@@ -107,9 +107,14 @@ Optionally, configure the binary location if the CLIs are not on PATH:
 - Allow Terminal (or your IDE) to control **Mail.app**
 
 **Full Disk Access (optional, recommended)**: Mail *read* commands use a fast
-direct-SQLite path (see "Direct SQLite read path" below) that requires Full
-Disk Access for Terminal (or the MCP host). Without it, reads silently fall
-back to the slower Mail.app Automation path.
+direct-SQLite path (see "Direct SQLite read path" below) that requires Full Disk
+Access for Terminal (or the MCP host); without it, `--engine auto` silently
+falls back to the slower Mail.app Automation path and `--engine sqlite` reports
+the missing grant as an error. `update`, `move`, `delete`, `batch-update` and
+`batch-delete` consult that same index for the message's row-id before
+writing — the write itself always goes through Mail.app either way — so the
+grant governs their lookup on the same terms, with Mail.app's
+mailbox-by-mailbox scan as the `auto` fallback.
 
 ### Development Installation
 
@@ -428,7 +433,12 @@ the database isn't readable. Message bodies come straight from the on-disk
 `.emlx` files. This is ~10–200× faster than the JXA path (subject search across
 an 80k-message mailbox: **~80ms vs ~15s**) and works even when Mail.app is not
 running. Mutations (`update`, `move`, `delete`, `send`, `reply`) always go
-through Mail.app.
+through Mail.app — nothing here ever writes to Mail's database. `update`,
+`move`, `delete`, `batch-update` and `batch-delete` do take `--engine` as well:
+under `auto` they look the message up in the same read-only index first, so
+Mail.app can be handed its row-id directly instead of scanning mailbox by
+mailbox, and they fall back to that scan whenever the lookup cannot answer.
+`send` and `reply` are unaffected.
 
 - The database is only ever opened **read-only** (`SQLITE_OPEN_READONLY` +
   `PRAGMA query_only`); the fast path never writes to Mail's data.
@@ -437,7 +447,11 @@ through Mail.app.
   `mail-cli auth-status` (`envelopeIndex.readable`) to see which path you get.
 - `--field content` search is not indexed locally and always uses JXA.
 - Force a specific path with `--engine sqlite` or `--engine jxa`; responses
-  from the fast path include `"engine": "sqlite"`.
+  from the fast path include `"engine": "sqlite"`. The write-path lookup emits
+  no `engine` key: `batch-update` and `batch-delete` report the locator built
+  in `_lookup.backend` (`sqlite` once an index opens, `jxa-only` otherwise) and
+  the hit/fallback counts in `_lookup.stats`; `update`, `move` and `delete`
+  carry a per-message `_lookup` inside `result` only under `MAIL_CLI_DEBUG=1`.
 
 ### Direct SMTP path (`mail-cli smtp-send`)
 

--- a/skills/apple-pim/references/mail-jxa.md
+++ b/skills/apple-pim/references/mail-jxa.md
@@ -1,6 +1,6 @@
 # Mail.app JXA Reference
 
-## Two engines: SQLite (reads) and JXA (everything else)
+## Two engines: SQLite (lookup) and JXA (every mutation)
 
 Read commands (`accounts`, `mailboxes`, `messages`, `get`, `search`) default to
 `--engine auto`: they query Apple Mail's **Envelope Index** SQLite database
@@ -10,7 +10,13 @@ works with Mail.app closed, but requires Full Disk Access. When the database
 isn't readable — or for `--field content` search, or when a body's `.emlx`
 hasn't been downloaded — the command silently falls back to JXA. Check
 `auth-status` → `envelopeIndex.readable` to see which path is active.
-Mutations (`update`, `move`, `delete`, `send`, `reply`) are always JXA/AppleScript.
+Mutations (`update`, `move`, `delete`, `send`, `reply`) are always performed by
+JXA/AppleScript — nothing here ever writes to Mail's database. `update`, `move`,
+`delete`, `batch-update` and `batch-delete` do take `--engine` as well: under
+`auto` they query the same read-only index first for the message's mailbox and
+row-id, so JXA can address it directly instead of scanning mailbox by mailbox,
+and they fall back to that scan whenever the lookup cannot answer. `send` and
+`reply` are unaffected.
 
 ## Why JXA?
 

--- a/swift/Sources/MailCLI/EnvelopeQueries.swift
+++ b/swift/Sources/MailCLI/EnvelopeQueries.swift
@@ -117,6 +117,46 @@ func mailboxScopeClause(rowIDs: [Int64], includeLabels: Bool) -> (
     )
 }
 
+// MARK: - Mailbox lookup priority
+
+/// The order the JXA finder sweeps mailboxes in, and the tie-breaker the write-path locator
+/// ranks rowid candidates by. Compared against a mailbox's LEAF name (`MailboxRef.name`):
+/// Gmail stores "All Mail" nested under "[Gmail]", and ranking the joined path would miss
+/// every entry here and sort the Gmail copy last.
+let mailboxPriority: [String] = [
+    "INBOX",
+    "Sent Messages", "Sent Mail", "Sent Items",
+    "Archive", "All Mail", "Drafts",
+    "Deleted Messages", "Deleted Items", "Trash",
+    "Junk", "Junk Email", "Junk E-mail", "Bulk", "Spam",
+]
+
+/// Position in `mailboxPriority`; unlisted mailboxes sort last. EXACT compare — this is the
+/// proposer, used to order candidates.
+func priorityRank(forMailboxName name: String) -> Int {
+    mailboxPriority.firstIndex(of: name) ?? mailboxPriority.count
+}
+
+/// `priorityRank` under the other reading of `mailboxes.whose({name: …})`: that Mail folds
+/// case, which is AppleScript's default for string comparison and is not settled here (probing
+/// it needs `osascript` at Mail). Only the write-path guard uses it — a mailbox named `Inbox`
+/// is unranked to `priorityRank` but is what a case-folding `whose({name: 'INBOX'})` reaches at
+/// rank 0, so the two ranks disagree exactly where the certification must decline.
+/// See `headMatchesJXASweep`.
+func priorityRankFoldingCase(forMailboxName name: String) -> Int {
+    mailboxPriority.firstIndex { $0.caseInsensitiveCompare(name) == .orderedSame }
+        ?? mailboxPriority.count
+}
+
+/// `mailboxPriority` as a JS array literal for interpolation into a generated script.
+func mailboxPriorityJSON() -> String {
+    guard let data = try? JSONSerialization.data(withJSONObject: mailboxPriority),
+          let json = String(data: data, encoding: .utf8) else {
+        return "[" + mailboxPriority.map { "'\($0)'" }.joined(separator: ",") + "]"
+    }
+    return json
+}
+
 /// Mailbox names Mail.app treats as junk destinations.
 private let junkMailboxNames: Set<String> = ["Junk", "Junk Mail", "Junk E-mail", "Junk Email", "Spam", "Bulk Mail"]
 

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -642,9 +642,14 @@ func buildReplyAppleScript(bodyPath: String, accountName: String, appleMailId: I
 /// Generates the JXA `findMsg(targetId)` function for batch operations.
 /// Unlike `findMessageJXA`, the target ID is a parameter (not hardcoded).
 ///
-/// NOTE: no production callers. Both batch commands now use `generateUnifiedFindMsgJXA`,
-/// whose fallback arm is this scan verbatim. Retained because `ScriptHelpersTests` covers it
-/// directly; deleting it means deleting that test too.
+/// NOTE: no production callers — both batch commands now use `generateUnifiedFindMsgJXA`.
+/// Retained as the reference this port was DERIVED from, not reproduced from: the port
+/// declares with `var`, hoists `priority` out of the function as `MAILBOX_PRIORITY`, counts
+/// `_stats.jxaFallbacks` and stamps `_perfMs` at each of the three return sites, and hands
+/// back `{msg, lookup}` instead of a bare message. What the two do share is the SWEEP —
+/// mailbox hint, then account-outer priority list, then the remaining mailboxes.
+/// `testBatchFindMessageJXAUsesNullHintsWhenNotProvided` still covers it directly; its sweep
+/// is deliberately no longer pinned, because nothing calls it.
 func batchFindMessageJXA(mailbox: String?, account: String?) -> String {
     let mailboxFilter = mailbox.map { "'\(escapeForJXA($0))'" } ?? "null"
     let accountFilter = account.map { "'\(escapeForJXA($0))'" } ?? "null"
@@ -707,8 +712,10 @@ func batchFindMessageJXA(mailbox: String?, account: String?) -> String {
     """
 }
 
-/// The write path's `findMsg(targetId)`: Envelope-Index ROWID fast path first, then the same
-/// `whose` scan the legacy finders do, unchanged.
+/// The write path's `findMsg(targetId)`: Envelope-Index ROWID fast path first, then a `whose`
+/// scan that sweeps in the same ORDER the legacy finders do — a port of their three arms, not
+/// a copy of them. The counters, the `_perfMs` gate and the `{msg, lookup}` return are new;
+/// `testBothShippedFindersSweepAccountOuterNotPriorityOuter` is what pins the shared order.
 ///
 /// Returns `{msg, lookup}` rather than a bare message, so every call site can carry the
 /// per-message lookup telemetry into its result. The emitted script assumes the caller has

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -641,6 +641,10 @@ func buildReplyAppleScript(bodyPath: String, accountName: String, appleMailId: I
 
 /// Generates the JXA `findMsg(targetId)` function for batch operations.
 /// Unlike `findMessageJXA`, the target ID is a parameter (not hardcoded).
+///
+/// NOTE: no production callers. Both batch commands now use `generateUnifiedFindMsgJXA`,
+/// whose fallback arm is this scan verbatim. Retained because `ScriptHelpersTests` covers it
+/// directly; deleting it means deleting that test too.
 func batchFindMessageJXA(mailbox: String?, account: String?) -> String {
     let mailboxFilter = mailbox.map { "'\(escapeForJXA($0))'" } ?? "null"
     let accountFilter = account.map { "'\(escapeForJXA($0))'" } ?? "null"
@@ -699,6 +703,196 @@ func batchFindMessageJXA(mailbox: String?, account: String?) -> String {
             }
         }
         return null;
+    }
+    """
+}
+
+/// The write path's `findMsg(targetId)`: Envelope-Index ROWID fast path first, then the same
+/// `whose` scan the legacy finders do, unchanged.
+///
+/// Returns `{msg, lookup}` rather than a bare message, so every call site can carry the
+/// per-message lookup telemetry into its result. The emitted script assumes the caller has
+/// already declared `const Mail = Application("Mail");`.
+func generateUnifiedFindMsgJXA(rowidMapJS: String, backend: String,
+                               mailbox: String?, account: String?,
+                               debug: Bool = ProcessInfo.processInfo
+                                   .environment["MAIL_CLI_DEBUG"] == "1") -> String {
+    let mailboxFilter = mailbox.map { "'\(escapeForJXA($0))'" } ?? "null"
+    let accountFilter = account.map { "'\(escapeForJXA($0))'" } ?? "null"
+    let debugMode = debug
+
+    return """
+    const rowidMap = \(rowidMapJS);
+    const mboxHint = \(mailboxFilter);
+    const acctHint = \(accountFilter);
+    const MAILBOX_PRIORITY = \(mailboxPriorityJSON());
+    const _locatorBackend = '\(backend)';
+    const _debug = \(debugMode ? "true" : "false");
+    var _stats = {byIdHits: 0, byIdMismatches: 0, jxaFallbacks: 0, notFound: 0};
+
+    function normalizeMessageId(raw) {
+        var s = (raw || '').replace(/^\\s+|\\s+$/g, '');
+        if (s.charAt(0) === '<') s = s.slice(1);
+        if (s.charAt(s.length - 1) === '>') s = s.slice(0, -1);
+        return s;
+    }
+
+    // Built ONCE, whole, on first use: an early return would leave the accounts after the
+    // match uncached, and a miss would re-enumerate every account on every later call —
+    // N account round-trips per message, on the batch path this port exists to speed up.
+    var _acctById = null;
+    function getAccountById(uuid) {
+        if (_acctById === null) {
+            _acctById = {};
+            var accts = [];
+            try { accts = Mail.accounts(); } catch(e) {}
+            for (var i = 0; i < accts.length; i++) {
+                try { _acctById[accts[i].id()] = accts[i]; } catch(e) {}
+            }
+        }
+        return _acctById[uuid] || null;
+    }
+
+    // Returns null rather than throwing, like every other Mail call on the byId arm: a
+    // candidate the fast path cannot resolve must fall through to the `whose` scan below,
+    // never fail a write the scan could still complete. This runs only when the account UUID
+    // did not resolve — the candidate's UUID comes from Mail's own accounts database while
+    // this arm matches against JXA's `account.id()`, and the account NAME is the fallback for
+    // any Mail version where those two do not agree.
+    function getAccountByName(name) {
+        var matches = [];
+        try { matches = Mail.accounts.whose({name: name})(); } catch(e) { return null; }
+        return matches.length > 0 ? matches[0] : null;
+    }
+
+    // ANY mailbox of the account: `messages.byId` is keyed to the Envelope-Index ROWID and
+    // resolves GLOBALLY, so the handle only has to belong to the right account — a rowid
+    // addressed through a mailbox that does not hold the message still returns that message.
+    // No mailbox NAME is compared, which is what makes the arm work on Gmail: Mail renames
+    // those mailboxes ("All Mail", no "[Gmail]" container) while the Envelope Index stores the
+    // server-side path, so any name compare skips every Gmail candidate — silently, and with
+    // the correct answer.
+    function anyMailboxOf(acct) {
+        var mbs = [];
+        try { mbs = acct.mailboxes(); } catch(e) { return null; }
+        return mbs.length > 0 ? mbs[0] : null;
+    }
+
+    function searchIn(mbox, targetId) {
+        try {
+            var found = mbox.messages.whose({messageId: targetId})();
+            if (found.length > 0) return found[0];
+        } catch(e) {}
+        return null;
+    }
+
+    function findMsg(targetId) {
+        var normalized = normalizeMessageId(targetId);
+        // Empty-id gate: '' also matches an unset messageId(), which Layer 1 could not then
+        // discriminate, so the byId path is skipped rather than given a compare that can't tell.
+        // Own-property check: a bare rowidMap[normalized] resolves an id that normalizes to an
+        // Object.prototype member (e.g. 'hasOwnProperty') to the inherited function and throws.
+        // Never a wrong copy, but a crafted id should not be able to fail a write.
+        var _own = normalized && Object.prototype.hasOwnProperty.call(rowidMap, normalized);
+        var candidates = _own ? rowidMap[normalized] : [];
+        // `candidates` is "how many copies the fast path may try", NOT a duplicate count: a
+        // contested id that Swift certified contributes its head alone, so 1 does not mean
+        // "one copy exists". 0 still cannot tell "declined" from "SQLite matched nothing".
+        var lookup = {method: 'none', candidates: candidates.length};
+        var _t0 = _debug ? Date.now() : 0;
+
+        for (var c = 0; c < candidates.length; c++) {
+            var cand = candidates[c];
+            var acct = null;
+            if (cand.acctId) acct = getAccountById(cand.acctId);
+            if (!acct && cand.acct) acct = getAccountByName(cand.acct);
+            if (!acct) continue;
+
+            var mb = anyMailboxOf(acct);
+            if (!mb) continue;
+
+            try {
+                var msg = mb.messages.byId(cand.r);
+                // Layer 1. A stale or reused ROWID can never be returned, only fallen through
+                // — which is what makes the fast path safe on its own for the flag writes,
+                // which carry no pre-op re-read, and what makes an arbitrary handle safe. A
+                // rowid Mail cannot resolve at all yields a specifier that throws on this
+                // first property read, which the catch below turns into the same fall-through.
+                if (normalizeMessageId(msg.messageId()) === normalized) {
+                    _stats.byIdHits++;
+                    lookup.method = 'byId';
+                    lookup.acctId = cand.acctId || '';
+                    lookup.mb = cand.mb || '';
+                    lookup.rowid = cand.r;
+                    if (_debug) {
+                        lookup._diag = {acctResolved: acct.name(), mbHandle: mb.name()};
+                        lookup._perfMs = Date.now() - _t0;
+                    }
+                    return {msg: msg, lookup: lookup};
+                }
+                _stats.byIdMismatches++;
+            } catch(e) {}
+        }
+
+        lookup.method = 'whose';
+        var accounts = acctHint ? Mail.accounts.whose({name: acctHint})() : Mail.accounts();
+        var searched = new Set();
+
+        if (mboxHint) {
+            for (var a = 0; a < accounts.length; a++) {
+                var mbs = accounts[a].mailboxes.whose({name: mboxHint})();
+                for (var m = 0; m < mbs.length; m++) {
+                    searched.add(accounts[a].name() + '/' + mbs[m].name());
+                    var r = searchIn(mbs[m], targetId);
+                    if (r) { _stats.jxaFallbacks++; if (_debug) lookup._perfMs = Date.now() - _t0; return {msg: r, lookup: lookup}; }
+                }
+            }
+        }
+
+        // Account-OUTER, exactly as `findMessageJXA` and `batchFindMessageJXA` sweep: one
+        // account's whole priority list is exhausted before the next account is considered.
+        // The nesting decides WHICH PHYSICAL COPY a delete or move acts on when the same
+        // Message-ID exists in two accounts, and neither drift guard can see the difference
+        // (both copies carry the same Message-ID, so both compares pass).
+        for (var a = 0; a < accounts.length; a++) {
+            for (var p = 0; p < MAILBOX_PRIORITY.length; p++) {
+                var mbs = accounts[a].mailboxes.whose({name: MAILBOX_PRIORITY[p]})();
+                for (var m = 0; m < mbs.length; m++) {
+                    var key = accounts[a].name() + '/' + mbs[m].name();
+                    if (searched.has(key)) continue;
+                    searched.add(key);
+                    var r = searchIn(mbs[m], targetId);
+                    if (r) { _stats.jxaFallbacks++; if (_debug) lookup._perfMs = Date.now() - _t0; return {msg: r, lookup: lookup}; }
+                }
+            }
+        }
+
+        for (var a = 0; a < accounts.length; a++) {
+            var mbs = accounts[a].mailboxes();
+            for (var m = 0; m < mbs.length; m++) {
+                var key = accounts[a].name() + '/' + mbs[m].name();
+                if (searched.has(key)) continue;
+                var r = searchIn(mbs[m], targetId);
+                if (r) { _stats.jxaFallbacks++; if (_debug) lookup._perfMs = Date.now() - _t0; return {msg: r, lookup: lookup}; }
+            }
+        }
+
+        _stats.notFound++;
+        return {msg: null, lookup: lookup};
+    }
+
+    // Per-message lookup detail is a DEBUG surface: it names an internal account UUID and an
+    // Envelope-Index ROWID, and it repeats on every entry of a batch. The process summary
+    // below is the opposite trade — four counters and a backend label, no identifiers, one
+    // object per run — and is emitted unconditionally, because it is the only way a caller can
+    // tell the fast path from the scan it falls back to.
+    function attachLookup(obj, lookup) {
+        if (_debug) obj._lookup = lookup;
+        return obj;
+    }
+
+    function getLookupSummary() {
+        return {backend: _locatorBackend, stats: _stats};
     }
     """
 }
@@ -1296,6 +1490,33 @@ struct UpdateMessage: AsyncParsableCommand {
     @Option(name: .long, help: "Account name hint (speeds up lookup)")
     var account: String?
 
+    @Option(name: .long, help: "Message-lookup engine: auto (SQLite rowid fast path with JXA fallback), sqlite, or jxa")
+    var engine: EngineChoice = .auto
+
+    /// No pre-op re-read here: a flag flip is reversible, so the post-`byId` messageId
+    /// verify inside `findMsg` is the whole guard. See the destructive commands for Layer 2.
+    static func buildScript(id: String, updateCode: String, findHelper: String) -> String {
+        """
+        const Mail = Application("Mail");
+        \(findHelper)
+
+        const _r = findMsg('\(escapeForJXA(id))');
+        const msg = _r.msg;
+        if (!msg) {
+            JSON.stringify(attachLookup({error: "Message not found: \(escapeForJXA(id))"}, _r.lookup));
+        } else {
+            \(updateCode)
+            JSON.stringify(attachLookup({
+                messageId: msg.messageId(),
+                subject: msg.subject(),
+                isRead: msg.readStatus(),
+                isFlagged: msg.flaggedStatus(),
+                isJunk: msg.junkMailStatus()
+            }, _r.lookup));
+        }
+        """
+    }
+
     func run() async throws {
         try ensureMailRunning()
         let config = pimOptions.loadConfig()
@@ -1317,27 +1538,10 @@ struct UpdateMessage: AsyncParsableCommand {
         }
 
         let updateCode = updates.joined(separator: "\n            ")
-        let findHelper = findMessageJXA(targetId: id, mailbox: mailbox, account: account)
+        let findHelper = try unifiedWriteFinderJXA(
+            for: [id], mailbox: mailbox, account: account, engine: engine)
 
-        let script = """
-        \(findHelper)
-
-        const msg = findMessage();
-        if (!msg) {
-            JSON.stringify({error: "Message not found: \(escapeForJXA(id))"});
-        } else {
-            \(updateCode)
-            JSON.stringify({
-                messageId: msg.messageId(),
-                subject: msg.subject(),
-                isRead: msg.readStatus(),
-                isFlagged: msg.flaggedStatus(),
-                isJunk: msg.junkMailStatus()
-            });
-        }
-        """
-
-        let raw = try runJXA(script)
+        let raw = try runJXA(Self.buildScript(id: id, updateCode: updateCode, findHelper: findHelper))
 
         if let dict = raw as? [String: Any], let error = dict["error"] as? String {
             throw CLIError.notFound(error)
@@ -1374,19 +1578,20 @@ struct MoveMessage: AsyncParsableCommand {
     @Option(name: .long, help: "Source account name hint (speeds up lookup)")
     var account: String?
 
-    func run() async throws {
-        try ensureMailRunning()
-        let config = pimOptions.loadConfig()
-        try checkMailEnabled(config: config)
+    @Option(name: .long, help: "Message-lookup engine: auto (SQLite rowid fast path with JXA fallback), sqlite, or jxa")
+    var engine: EngineChoice = .auto
 
+    /// Layer 2: re-read the messageId immediately before the move and abort if it drifted.
+    /// A move is not reversible from here, so the post-`byId` verify is not the only guard.
+    static func buildScript(id: String, toMailbox: String, toAccount: String?,
+                            findHelper: String) -> String {
         let escapedMailbox = escapeForJXA(toMailbox)
         let toAccountFilter = toAccount.map { "'\(escapeForJXA($0))'" } ?? "null"
-        let findHelper = findMessageJXA(targetId: id, mailbox: mailbox, account: account)
 
-        let script = """
+        return """
+        const Mail = Application("Mail");
         \(findHelper)
 
-        const Mail = Application("Mail");
         const destMailboxName = '\(escapedMailbox)';
         const destAccountName = \(toAccountFilter);
 
@@ -1401,28 +1606,44 @@ struct MoveMessage: AsyncParsableCommand {
             return null;
         }
 
-        const msg = findMessage();
+        const _r = findMsg('\(escapeForJXA(id))');
+        const msg = _r.msg;
         if (!msg) {
-            JSON.stringify({error: "Message not found: \(escapeForJXA(id))"});
+            JSON.stringify(attachLookup({error: "Message not found: \(escapeForJXA(id))"}, _r.lookup));
         } else {
             const sourceAccount = msg.mailbox().account();
             const destMbox = findDestMailbox(sourceAccount);
             if (!destMbox) {
-                JSON.stringify({error: "Destination mailbox not found: " + destMailboxName});
+                JSON.stringify(attachLookup({error: "Destination mailbox not found: " + destMailboxName}, _r.lookup));
             } else {
-                const fromMailbox = msg.mailbox().name();
-                Mail.move(msg, {to: destMbox});
-                JSON.stringify({
-                    messageId: '\(escapeForJXA(id))',
-                    from: fromMailbox,
-                    to: destMailboxName,
-                    moved: true
-                });
+                var preOpId = normalizeMessageId(msg.messageId());
+                if (preOpId !== normalizeMessageId('\(escapeForJXA(id))')) {
+                    JSON.stringify(attachLookup({error: 'messageId drift detected before move (expected \(escapeForJXA(id)), got ' + preOpId + ')'}, _r.lookup));
+                } else {
+                    const fromMailbox = msg.mailbox().name();
+                    Mail.move(msg, {to: destMbox});
+                    JSON.stringify(attachLookup({
+                        messageId: '\(escapeForJXA(id))',
+                        from: fromMailbox,
+                        to: destMailboxName,
+                        moved: true
+                    }, _r.lookup));
+                }
             }
         }
         """
+    }
 
-        let raw = try runJXA(script)
+    func run() async throws {
+        try ensureMailRunning()
+        let config = pimOptions.loadConfig()
+        try checkMailEnabled(config: config)
+
+        let findHelper = try unifiedWriteFinderJXA(
+            for: [id], mailbox: mailbox, account: account, engine: engine)
+
+        let raw = try runJXA(Self.buildScript(
+            id: id, toMailbox: toMailbox, toAccount: toAccount, findHelper: findHelper))
 
         if let dict = raw as? [String: Any], let error = dict["error"] as? String {
             throw CLIError.notFound(error)
@@ -1453,34 +1674,47 @@ struct DeleteMessage: AsyncParsableCommand {
     @Option(name: .long, help: "Account name hint (speeds up lookup)")
     var account: String?
 
+    @Option(name: .long, help: "Message-lookup engine: auto (SQLite rowid fast path with JXA fallback), sqlite, or jxa")
+    var engine: EngineChoice = .auto
+
+    /// Layer 2: re-read the messageId immediately before the delete and abort if it drifted.
+    static func buildScript(id: String, findHelper: String) -> String {
+        """
+        const Mail = Application("Mail");
+        \(findHelper)
+
+        const _r = findMsg('\(escapeForJXA(id))');
+        const msg = _r.msg;
+        if (!msg) {
+            JSON.stringify(attachLookup({error: "Message not found: \(escapeForJXA(id))"}, _r.lookup));
+        } else {
+            var preOpId = normalizeMessageId(msg.messageId());
+            if (preOpId !== normalizeMessageId('\(escapeForJXA(id))')) {
+                JSON.stringify(attachLookup({error: 'messageId drift detected before delete (expected \(escapeForJXA(id)), got ' + preOpId + ')'}, _r.lookup));
+            } else {
+                const subject = msg.subject();
+                const mboxName = msg.mailbox().name();
+                Mail.delete(msg);
+                JSON.stringify(attachLookup({
+                    messageId: '\(escapeForJXA(id))',
+                    subject: subject,
+                    fromMailbox: mboxName,
+                    deleted: true
+                }, _r.lookup));
+            }
+        }
+        """
+    }
+
     func run() async throws {
         try ensureMailRunning()
         let config = pimOptions.loadConfig()
         try checkMailEnabled(config: config)
 
-        let findHelper = findMessageJXA(targetId: id, mailbox: mailbox, account: account)
+        let findHelper = try unifiedWriteFinderJXA(
+            for: [id], mailbox: mailbox, account: account, engine: engine)
 
-        let script = """
-        \(findHelper)
-
-        const Mail = Application("Mail");
-        const msg = findMessage();
-        if (!msg) {
-            JSON.stringify({error: "Message not found: \(escapeForJXA(id))"});
-        } else {
-            const subject = msg.subject();
-            const mboxName = msg.mailbox().name();
-            Mail.delete(msg);
-            JSON.stringify({
-                messageId: '\(escapeForJXA(id))',
-                subject: subject,
-                fromMailbox: mboxName,
-                deleted: true
-            });
-        }
-        """
-
-        let raw = try runJXA(script)
+        let raw = try runJXA(Self.buildScript(id: id, findHelper: findHelper))
 
         if let dict = raw as? [String: Any], let error = dict["error"] as? String {
             throw CLIError.notFound(error)
@@ -1520,6 +1754,52 @@ struct BatchUpdateMessages: AsyncParsableCommand {
     @Option(name: .long, help: "Account name hint (speeds up lookup)")
     var account: String?
 
+    @Option(name: .long, help: "Message-lookup engine: auto (SQLite rowid fast path with JXA fallback), sqlite, or jxa")
+    var engine: EngineChoice = .auto
+
+    /// The measured hot path: one `findMsg` per message, previously a full mailbox scan
+    /// each, which put a ten-message batch against the 30s osascript cap. No pre-op re-read
+    /// (flag flips are reversible); the post-`byId` verify is the guard.
+    static func buildScript(jsUpdates: String, findHelper: String) -> String {
+        """
+        const Mail = Application("Mail");
+        const updates = [
+            \(jsUpdates)
+        ];
+        \(findHelper)
+
+        const results = [];
+        const errors = [];
+
+        for (const u of updates) {
+            try {
+                const _r = findMsg(u.id);
+                const msg = _r.msg;
+                if (!msg) {
+                    errors.push(attachLookup({id: u.id, error: 'Message not found'}, _r.lookup));
+                    continue;
+                }
+                if (u.read !== undefined) msg.readStatus = u.read;
+                if (u.flagged !== undefined) msg.flaggedStatus = u.flagged;
+                if (u.junk !== undefined) msg.junkMailStatus = u.junk;
+                results.push(attachLookup({
+                    id: u.id,
+                    subject: msg.subject(),
+                    isRead: msg.readStatus(),
+                    isFlagged: msg.flaggedStatus(),
+                    isJunk: msg.junkMailStatus()
+                }, _r.lookup));
+            } catch(e) {
+                errors.push({id: u.id, error: e.message || String(e)});
+            }
+        }
+
+        var output = {results: results, errors: errors};
+        output._lookup = getLookupSummary();
+        JSON.stringify(output);
+        """
+    }
+
     func run() async throws {
         try ensureMailRunning()
         let config = pimOptions.loadConfig()
@@ -1544,44 +1824,12 @@ struct BatchUpdateMessages: AsyncParsableCommand {
             return "{\(fields.joined(separator: ", "))}"
         }.joined(separator: ",\n            ")
 
-        let findMsgFunc = batchFindMessageJXA(mailbox: mailbox, account: account)
+        // Every id in one resolve: 10 prepared statements against a local SQLite file are
+        // free next to a single Apple Events round-trip.
+        let findHelper = try unifiedWriteFinderJXA(
+            for: updates.map { $0.id }, mailbox: mailbox, account: account, engine: engine)
 
-        let script = """
-        const Mail = Application("Mail");
-        const updates = [
-            \(jsUpdates)
-        ];
-        \(findMsgFunc)
-
-        const results = [];
-        const errors = [];
-
-        for (const u of updates) {
-            try {
-                const msg = findMsg(u.id);
-                if (!msg) {
-                    errors.push({id: u.id, error: 'Message not found'});
-                    continue;
-                }
-                if (u.read !== undefined) msg.readStatus = u.read;
-                if (u.flagged !== undefined) msg.flaggedStatus = u.flagged;
-                if (u.junk !== undefined) msg.junkMailStatus = u.junk;
-                results.push({
-                    id: u.id,
-                    subject: msg.subject(),
-                    isRead: msg.readStatus(),
-                    isFlagged: msg.flaggedStatus(),
-                    isJunk: msg.junkMailStatus()
-                });
-            } catch(e) {
-                errors.push({id: u.id, error: e.message || String(e)});
-            }
-        }
-
-        JSON.stringify({results: results, errors: errors});
-        """
-
-        let raw = try runJXA(script)
+        let raw = try runJXA(Self.buildScript(jsUpdates: jsUpdates, findHelper: findHelper))
 
         guard let dict = raw as? [String: Any] else {
             throw CLIError.jxaError("Unexpected output from batch update")
@@ -1590,14 +1838,16 @@ struct BatchUpdateMessages: AsyncParsableCommand {
         let results = dict["results"] as? [Any] ?? []
         let errors = dict["errors"] as? [Any] ?? []
 
-        outputJSON([
+        var output: [String: Any] = [
             "success": errors.isEmpty,
             "message": "Batch update completed",
             "updated": results,
             "updatedCount": results.count,
             "errors": errors,
-            "errorCount": errors.count
-        ])
+            "errorCount": errors.count,
+        ]
+        if let lookup = dict["_lookup"] { output["_lookup"] = lookup }
+        outputJSON(output)
     }
 }
 
@@ -1618,6 +1868,48 @@ struct BatchDeleteMessages: AsyncParsableCommand {
     @Option(name: .long, help: "Account name hint (speeds up lookup)")
     var account: String?
 
+    @Option(name: .long, help: "Message-lookup engine: auto (SQLite rowid fast path with JXA fallback), sqlite, or jxa")
+    var engine: EngineChoice = .auto
+
+    /// Layer 2 per entry: a drifted id is pushed to `errors` and skipped so the rest of the
+    /// batch still runs, rather than abandoning the whole call.
+    static func buildScript(jsIds: String, findHelper: String) -> String {
+        """
+        const Mail = Application("Mail");
+        const ids = [\(jsIds)];
+        \(findHelper)
+
+        const results = [];
+        const errors = [];
+
+        for (const targetId of ids) {
+            try {
+                const _r = findMsg(targetId);
+                const msg = _r.msg;
+                if (!msg) {
+                    errors.push(attachLookup({id: targetId, error: 'Message not found'}, _r.lookup));
+                    continue;
+                }
+                var preOpId = normalizeMessageId(msg.messageId());
+                if (preOpId !== normalizeMessageId(targetId)) {
+                    errors.push(attachLookup({id: targetId, error: 'messageId drift detected before delete (expected ' + targetId + ', got ' + preOpId + ')'}, _r.lookup));
+                    continue;
+                }
+                const subject = msg.subject();
+                const mboxName = msg.mailbox().name();
+                Mail.delete(msg);
+                results.push(attachLookup({id: targetId, subject: subject, fromMailbox: mboxName}, _r.lookup));
+            } catch(e) {
+                errors.push({id: targetId, error: e.message || String(e)});
+            }
+        }
+
+        var output = {results: results, errors: errors};
+        output._lookup = getLookupSummary();
+        JSON.stringify(output);
+        """
+    }
+
     func run() async throws {
         try ensureMailRunning()
         let config = pimOptions.loadConfig()
@@ -1633,36 +1925,10 @@ struct BatchDeleteMessages: AsyncParsableCommand {
         }
 
         let jsIds = ids.map { "'\(escapeForJXA($0))'" }.joined(separator: ", ")
-        let findMsgFunc = batchFindMessageJXA(mailbox: mailbox, account: account)
+        let findHelper = try unifiedWriteFinderJXA(
+            for: ids, mailbox: mailbox, account: account, engine: engine)
 
-        let script = """
-        const Mail = Application("Mail");
-        const ids = [\(jsIds)];
-        \(findMsgFunc)
-
-        const results = [];
-        const errors = [];
-
-        for (const targetId of ids) {
-            try {
-                const msg = findMsg(targetId);
-                if (!msg) {
-                    errors.push({id: targetId, error: 'Message not found'});
-                    continue;
-                }
-                const subject = msg.subject();
-                const mboxName = msg.mailbox().name();
-                Mail.delete(msg);
-                results.push({id: targetId, subject: subject, fromMailbox: mboxName});
-            } catch(e) {
-                errors.push({id: targetId, error: e.message || String(e)});
-            }
-        }
-
-        JSON.stringify({results: results, errors: errors});
-        """
-
-        let raw = try runJXA(script)
+        let raw = try runJXA(Self.buildScript(jsIds: jsIds, findHelper: findHelper))
 
         guard let dict = raw as? [String: Any] else {
             throw CLIError.jxaError("Unexpected output from batch delete")
@@ -1671,14 +1937,16 @@ struct BatchDeleteMessages: AsyncParsableCommand {
         let results = dict["results"] as? [Any] ?? []
         let errors = dict["errors"] as? [Any] ?? []
 
-        outputJSON([
+        var output: [String: Any] = [
             "success": errors.isEmpty,
             "message": "Batch delete completed",
             "deleted": results,
             "deletedCount": results.count,
             "errors": errors,
-            "errorCount": errors.count
-        ])
+            "errorCount": errors.count,
+        ]
+        if let lookup = dict["_lookup"] { output["_lookup"] = lookup }
+        outputJSON(output)
     }
 }
 

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -903,6 +903,17 @@ func generateUnifiedFindMsgJXA(rowidMapJS: String, backend: String,
         return obj;
     }
 
+    // What the single-message commands attach instead. They run exactly one findMsg per
+    // process, so the counters below ARE that lookup's own tally, and its `stats` key carries
+    // the same four numbers the batch summary carries for a whole run. A batch ENTRY keeps
+    // the bare lookup: attached mid-loop, these counters are a running total and not that
+    // entry's. Delegating leaves `attachLookup` the only place the gated key is written, so
+    // the debug gate stays in one spot and the un-gated surface is untouched.
+    function attachLookupWithStats(obj, lookup) {
+        if (_debug) lookup.stats = _stats;
+        return attachLookup(obj, lookup);
+    }
+
     function getLookupSummary() {
         return {backend: _locatorBackend, stats: _stats};
     }
@@ -1515,10 +1526,10 @@ struct UpdateMessage: AsyncParsableCommand {
         const _r = findMsg('\(escapeForJXA(id))');
         const msg = _r.msg;
         if (!msg) {
-            JSON.stringify(attachLookup({error: "Message not found: \(escapeForJXA(id))"}, _r.lookup));
+            JSON.stringify(attachLookupWithStats({error: "Message not found: \(escapeForJXA(id))"}, _r.lookup));
         } else {
             \(updateCode)
-            JSON.stringify(attachLookup({
+            JSON.stringify(attachLookupWithStats({
                 messageId: msg.messageId(),
                 subject: msg.subject(),
                 isRead: msg.readStatus(),
@@ -1621,20 +1632,20 @@ struct MoveMessage: AsyncParsableCommand {
         const _r = findMsg('\(escapeForJXA(id))');
         const msg = _r.msg;
         if (!msg) {
-            JSON.stringify(attachLookup({error: "Message not found: \(escapeForJXA(id))"}, _r.lookup));
+            JSON.stringify(attachLookupWithStats({error: "Message not found: \(escapeForJXA(id))"}, _r.lookup));
         } else {
             const sourceAccount = msg.mailbox().account();
             const destMbox = findDestMailbox(sourceAccount);
             if (!destMbox) {
-                JSON.stringify(attachLookup({error: "Destination mailbox not found: " + destMailboxName}, _r.lookup));
+                JSON.stringify(attachLookupWithStats({error: "Destination mailbox not found: " + destMailboxName}, _r.lookup));
             } else {
                 var preOpId = normalizeMessageId(msg.messageId());
                 if (preOpId !== normalizeMessageId('\(escapeForJXA(id))')) {
-                    JSON.stringify(attachLookup({error: 'messageId drift detected before move (expected \(escapeForJXA(id)), got ' + preOpId + ')'}, _r.lookup));
+                    JSON.stringify(attachLookupWithStats({error: 'messageId drift detected before move (expected \(escapeForJXA(id)), got ' + preOpId + ')'}, _r.lookup));
                 } else {
                     const fromMailbox = msg.mailbox().name();
                     Mail.move(msg, {to: destMbox});
-                    JSON.stringify(attachLookup({
+                    JSON.stringify(attachLookupWithStats({
                         messageId: '\(escapeForJXA(id))',
                         from: fromMailbox,
                         to: destMailboxName,
@@ -1698,16 +1709,16 @@ struct DeleteMessage: AsyncParsableCommand {
         const _r = findMsg('\(escapeForJXA(id))');
         const msg = _r.msg;
         if (!msg) {
-            JSON.stringify(attachLookup({error: "Message not found: \(escapeForJXA(id))"}, _r.lookup));
+            JSON.stringify(attachLookupWithStats({error: "Message not found: \(escapeForJXA(id))"}, _r.lookup));
         } else {
             var preOpId = normalizeMessageId(msg.messageId());
             if (preOpId !== normalizeMessageId('\(escapeForJXA(id))')) {
-                JSON.stringify(attachLookup({error: 'messageId drift detected before delete (expected \(escapeForJXA(id)), got ' + preOpId + ')'}, _r.lookup));
+                JSON.stringify(attachLookupWithStats({error: 'messageId drift detected before delete (expected \(escapeForJXA(id)), got ' + preOpId + ')'}, _r.lookup));
             } else {
                 const subject = msg.subject();
                 const mboxName = msg.mailbox().name();
                 Mail.delete(msg);
-                JSON.stringify(attachLookup({
+                JSON.stringify(attachLookupWithStats({
                     messageId: '\(escapeForJXA(id))',
                     subject: subject,
                     fromMailbox: mboxName,

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -768,6 +768,8 @@ func generateUnifiedFindMsgJXA(rowidMapJS: String, backend: String,
     // ANY mailbox of the account: `messages.byId` is keyed to the Envelope-Index ROWID and
     // resolves GLOBALLY, so the handle only has to belong to the right account — a rowid
     // addressed through a mailbox that does not hold the message still returns that message.
+    // That is a PROPERTY-access rule and it is what this handle is for: LOCATING. The accept
+    // block re-anchors before returning, because the act commands do not share it.
     // No mailbox NAME is compared, which is what makes the arm work on Gmail: Mail renames
     // those mailboxes ("All Mail", no "[Gmail]" container) while the Envelope Index stores the
     // server-side path, so any name compare skips every Gmail candidate — silently, and with
@@ -818,7 +820,17 @@ func generateUnifiedFindMsgJXA(rowidMapJS: String, backend: String,
                 // which carry no pre-op re-read, and what makes an arbitrary handle safe. A
                 // rowid Mail cannot resolve at all yields a specifier that throws on this
                 // first property read, which the catch below turns into the same fall-through.
+                //
+                // Then the re-anchor, first thing inside the accept: the handle that FOUND
+                // the message cannot ACT on it. byId resolves the ROWID globally for PROPERTY
+                // access — the compare above, the flag writes the callers do — but the delete
+                // and move commands re-resolve the specifier's container chain and refuse
+                // unless that mailbox holds the message, so the verified rowid is re-addressed
+                // through the message's own. Left unguarded: a throw belongs to the catch
+                // below, which drops the candidate to the scan and is counted there as a
+                // fallback, not a hit that never acted — which is why it precedes the counter.
                 if (normalizeMessageId(msg.messageId()) === normalized) {
+                    msg = msg.mailbox().messages.byId(cand.r);
                     _stats.byIdHits++;
                     lookup.method = 'byId';
                     lookup.acctId = cand.acctId || '';

--- a/swift/Sources/MailCLI/MessageLocator.swift
+++ b/swift/Sources/MailCLI/MessageLocator.swift
@@ -39,8 +39,18 @@ protocol MessageLocator {
     func isAvailable() -> Bool
 }
 
-/// Trim, then drop angle brackets. Must agree with the `normalizeMessageId` twin emitted
-/// into the generated JXA, or the script looks candidates up under a key that is not there.
+/// Trim, then drop angle brackets. This keys the rowid map the emitted JXA reads, so it has to
+/// agree with the `normalizeMessageId` twin emitted into that script, or the script looks
+/// candidates up under a key that is not there.
+///
+/// On one input class it does not agree, knowingly: `.whitespaces` excludes newlines, while
+/// the twin trims `/^\s+|\s+$/`, which includes them. A Message-ID carrying a leading or
+/// trailing newline is therefore keyed here with the newline still attached — and with its
+/// brackets, since the strip runs after the trim and no longer sees them — while the script
+/// looks it up with both gone. The cost is acceleration, never a wrong write: a missing key
+/// yields zero candidates, the same as an id the index declined, and the scan the command
+/// falls back to is handed the raw id, exactly as the legacy finders hand it over.
+///
 /// Deliberately separate from `stripAngleBrackets`, which sits on the read output path.
 func normalizeMessageIDForLookup(_ raw: String) -> String {
     stripAngleBrackets(raw.trimmingCharacters(in: .whitespaces))

--- a/swift/Sources/MailCLI/MessageLocator.swift
+++ b/swift/Sources/MailCLI/MessageLocator.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+// Write-path message lookup acceleration: resolves Message-IDs against the local Envelope
+// Index and hands JXA a ranked list of ROWIDs it can address with `mailbox.messages.byId`,
+// instead of a per-mailbox `whose({messageId: ...})` scan. SQLite performs no part of the
+// write — every candidate is re-verified by Message-ID on the JXA side before use, and a
+// locator that cannot answer emits an empty map, leaving today's scan unchanged.
+
+/// One Envelope-Index copy of a message: where it lives and how to address it from JXA.
+struct ResolvedRef {
+    let normalizedMessageId: String
+    let rowid: Int64
+    let mailboxURL: String
+    /// Leaf mailbox name as the Envelope Index stores it. Swift-side, the candidate sort and
+    /// both arms of `headMatchesJXASweep` read it to rank one copy against another. Emitted
+    /// only as the per-message lookup telemetry's `mb`; never used to address anything, since
+    /// Mail renames some mailboxes it shows.
+    let mailboxName: String
+    /// Percent-decoded mailbox path from the account root, e.g. ["[Gmail]", "All Mail"].
+    /// Swift-side only — `headMatchesJXASweep` reads it to tell a top-level copy from one the
+    /// server files deeper. Not emitted: JXA addresses a candidate by account plus rowid.
+    let mailboxPathComponents: [String]
+    let accountUUID: String?
+    let accountName: String?
+}
+
+/// Batch-resolves RFC 2822 Message-IDs to ordered rowid candidates.
+///
+/// `account` is a hard filter (unspecified searches everywhere; specified-and-unknown yields no
+/// candidates, matching the JXA scan). `mailbox` is a sort preference, not a filter.
+///
+/// Candidate ORDER selects which physical copy a write acts on, so an id whose copies the JXA
+/// scan might reach in a different order resolves to an EMPTY list instead — see
+/// `SQLiteEngine.resolve` / `headMatchesJXASweep`. A survivor resolves to its HEAD alone,
+/// already chosen, never a set to pick between.
+protocol MessageLocator {
+    func resolve(messageIds: [String], mailbox: String?, account: String?) throws -> [String: [ResolvedRef]]
+    /// False when no Envelope Index is behind this locator, so nothing can be accelerated.
+    func isAvailable() -> Bool
+}
+
+/// Trim, then drop angle brackets. Must agree with the `normalizeMessageId` twin emitted
+/// into the generated JXA, or the script looks candidates up under a key that is not there.
+/// Deliberately separate from `stripAngleBrackets`, which sits on the read output path.
+func normalizeMessageIDForLookup(_ raw: String) -> String {
+    stripAngleBrackets(raw.trimmingCharacters(in: .whitespaces))
+}
+
+/// Resolves nothing. Used when the caller asked for JXA, and when no Envelope Index can be
+/// opened (typically no Full Disk Access) under `--engine auto`.
+struct NoopLocator: MessageLocator {
+    func resolve(messageIds: [String], mailbox: String?, account: String?) throws -> [String: [ResolvedRef]] {
+        var result: [String: [ResolvedRef]] = [:]
+        for id in messageIds { result[normalizeMessageIDForLookup(id)] = [] }
+        return result
+    }
+
+    func isAvailable() -> Bool { false }
+}
+
+/// Build the locator a write command should use.
+///
+/// SQLite never performs the write, so `--engine sqlite` cannot mean "refuse to write" —
+/// it means "refuse to run degraded", and says so rather than silently taking the slow path.
+/// - `jxa`: no locator, no database opened.
+/// - `auto`: locator when one can be opened, silently Noop otherwise.
+/// - `sqlite`: locator required; an open failure is reported to the caller.
+func makeMessageLocator(engine: EngineChoice) throws -> MessageLocator {
+    guard engine != .jxa else { return NoopLocator() }
+    do {
+        return try SQLiteEngine()
+    } catch {
+        try rethrowIfForcedSQLite(engine, error)
+        return NoopLocator()
+    }
+}
+
+/// The JS rowid map for a write command, plus the backend label its telemetry reports.
+///
+/// Never fails the command under `auto`/`jxa`: a locator that cannot answer degrades to an
+/// empty map, and the JXA scan runs unchanged.
+func resolveRowidMap(for messageIds: [String], mailbox: String?, account: String?,
+                     engine: EngineChoice) throws -> (js: String, backend: String) {
+    let locator = try makeMessageLocator(engine: engine)
+    let backend = locator.isAvailable() ? "sqlite" : "jxa-only"
+    do {
+        let refs = try locator.resolve(messageIds: messageIds, mailbox: mailbox, account: account)
+        return (buildRowidMapJS(refs), backend)
+    } catch {
+        try rethrowIfForcedSQLite(engine, error)
+        return (buildRowidMapJS([:]), "jxa-only")
+    }
+}
+
+/// The `findMsg` helper every write command embeds: resolve the ids it is about to act on,
+/// then generate the unified finder around the resulting rowid map.
+///
+/// One seam for all five commands rather than the same two calls repeated in each `run()`.
+/// Which finder a write uses is not a per-command choice — the legacy finders carry no rowid
+/// fast path and no post-`byId` messageId verify — so there is one place to read it and one
+/// place a test can hold.
+func unifiedWriteFinderJXA(for messageIds: [String], mailbox: String?, account: String?,
+                           engine: EngineChoice) throws -> String {
+    let resolved = try resolveRowidMap(
+        for: messageIds, mailbox: mailbox, account: account, engine: engine)
+    return generateUnifiedFindMsgJXA(
+        rowidMapJS: resolved.js, backend: resolved.backend, mailbox: mailbox, account: account)
+}
+
+/// Serialize resolved candidates as the `rowidMap` JS object literal:
+/// `{"<bracket-stripped id>": [{r, mb, acctId, acct}, …]}`, candidates in rank order.
+///
+/// `r` plus the account is the whole address — `messages.byId` resolves a ROWID globally
+/// within the account — so no mailbox path travels to JXA; `mb` rides along for telemetry.
+///
+/// Not routed through `escapeForJXA`: `JSONSerialization` output is already valid JS literal
+/// syntax. A serialization failure returns `{}` so the script degrades to the pure-JXA scan
+/// rather than carrying broken JS into `osascript`.
+func buildRowidMapJS(_ refs: [String: [ResolvedRef]]) -> String {
+    var map: [String: [[String: Any]]] = [:]
+    for (id, candidates) in refs {
+        map[id] = candidates.map { ref in
+            var obj: [String: Any] = ["r": ref.rowid, "mb": ref.mailboxName]
+            if let uuid = ref.accountUUID { obj["acctId"] = uuid }
+            if let name = ref.accountName { obj["acct"] = name }
+            return obj
+        }
+    }
+    guard let data = try? JSONSerialization.data(withJSONObject: map, options: [.sortedKeys]),
+          let json = String(data: data, encoding: .utf8) else {
+        return "{}"
+    }
+    return json
+}

--- a/swift/Sources/MailCLI/SQLiteEngine.swift
+++ b/swift/Sources/MailCLI/SQLiteEngine.swift
@@ -301,10 +301,16 @@ extension SQLiteEngine: MessageLocator {
                  account: String?) throws -> [String: [ResolvedRef]] {
         guard !messageIds.isEmpty else { return [:] }
 
-        // The account filter matches JXA's `.whose({name: acctHint})`: unresolved yields no
-        // candidates, not an error, so `--engine auto`'s JXA scan can still complete the write.
-        // Wider than an exact match (display name / user name / raw UUID, case-insensitive),
-        // read through the parent-COALESCE join so IMAP child accounts resolve too.
+        // A hard filter, and an unresolved hint yields no candidates rather than an error, so
+        // `--engine auto`'s JXA scan can still complete the write.
+        //
+        // Its NAMESPACE is wider than the scan's, which is not a difference of degree: this
+        // resolves a raw account UUID first, then the display name, then the user name
+        // (case-insensitive, read through the parent-COALESCE join so IMAP child accounts
+        // resolve too), while the scan it falls back to matches `account.name()` alone
+        // (`Mail.accounts.whose({name: acctHint})`). A UUID or user-name hint therefore
+        // accelerates here and matches no account there — the same command completes under
+        // `--engine auto` and reports "Message not found" under `--engine jxa`.
         //
         // `try?` swallows `.ambiguous` on purpose — fail OPEN: an empty UUID set skips the byId
         // path and lets JXA pick exactly as it would with no locator. Correct but slow, never

--- a/swift/Sources/MailCLI/SQLiteEngine.swift
+++ b/swift/Sources/MailCLI/SQLiteEngine.swift
@@ -36,8 +36,7 @@ struct SQLiteEngine {
     private let mailboxByRowID: [Int64: MailboxRef]
 
     init() throws {
-        let index = try EnvelopeIndex.open()
-        self.init(index: index, allMailboxes: try index.mailboxes())
+        try self.init(index: EnvelopeIndex.open())
     }
 
     init(index: EnvelopeIndex, allMailboxes: [MailboxRef]) {
@@ -45,6 +44,13 @@ struct SQLiteEngine {
         self.allMailboxes = allMailboxes
         mailboxByURL = Dictionary(uniqueKeysWithValues: allMailboxes.map { ($0.url, $0) })
         mailboxByRowID = Dictionary(uniqueKeysWithValues: allMailboxes.map { ($0.rowid, $0) })
+    }
+
+    /// Open against an already-discovered index, deriving the mailbox inventory from it.
+    /// Lets tests drive the engine from a throwaway fixture database instead of the caller's
+    /// real Envelope Index, without also having to hand-build the inventory.
+    init(index: EnvelopeIndex) throws {
+        self.init(index: index, allMailboxes: try index.mailboxes())
     }
 
     private func accountDisplayName(_ uuid: String) -> String {
@@ -75,6 +81,18 @@ struct SQLiteEngine {
             return logicalMailbox
         }
         return (row["mailbox_url"] as? String).flatMap { mailboxByURL[$0] }
+    }
+
+    /// URL-keyed lookup for the WRITE path, deliberately separate from `mailboxRef(forRow:)`
+    /// (which prefers the LOGICAL mailbox a Gmail label displays a message under). A write must
+    /// address the PHYSICAL mailbox — the one with an on-disk store, the only one
+    /// `mailbox.messages.byId(rowid)` can reach and the one `mail delete` destroys a copy in.
+    ///
+    /// Currently latent (no locator row source projects the logical rowid yet) but pins the
+    /// invariant for when one does. See
+    /// `MessageLocatorTests.testLocatorResolvesToThePHYSICALMailboxNotTheLogicalOne`.
+    private func mailboxRef(forURL url: String?) -> MailboxRef? {
+        url.flatMap { mailboxByURL[$0] }
     }
 
     // MARK: - Row mapping
@@ -268,4 +286,194 @@ struct SQLiteEngine {
         info["messageCount"] = (try? index.messageCount()) ?? 0
         return info
     }
+}
+
+// MARK: - Write-path message locator
+
+// Lives here rather than beside the protocol because everything it needs is already on the
+// engine and file-private: `mailboxByURL`, `accountDisplayName`, and the one open database
+// handle with its cached labels probe and account-name map. A standalone locator would open
+// a second handle against a file Mail.app writes continuously and duplicate both caches.
+extension SQLiteEngine: MessageLocator {
+    func isAvailable() -> Bool { true }
+
+    func resolve(messageIds: [String], mailbox: String?,
+                 account: String?) throws -> [String: [ResolvedRef]] {
+        guard !messageIds.isEmpty else { return [:] }
+
+        // The account filter matches JXA's `.whose({name: acctHint})`: unresolved yields no
+        // candidates, not an error, so `--engine auto`'s JXA scan can still complete the write.
+        // Wider than an exact match (display name / user name / raw UUID, case-insensitive),
+        // read through the parent-COALESCE join so IMAP child accounts resolve too.
+        //
+        // `try?` swallows `.ambiguous` on purpose — fail OPEN: an empty UUID set skips the byId
+        // path and lets JXA pick exactly as it would with no locator. Correct but slow, never
+        // wrong. Pinned by
+        // `MessageLocatorTests.testAnAMBIGUOUSAccountHintFailsOPENToEmptyCandidates`.
+        var accountUUIDs: Set<String>?
+        if let account {
+            accountUUIDs = Set((try? index.accountUUIDs(matching: account)) ?? [])
+        }
+
+        // Every requested id is a key, so the JXA side can tell "resolved to nothing" from
+        // "never asked for" without a second contract.
+        var candidateMap: [String: [ResolvedRef]] = [:]
+        for id in messageIds { candidateMap[normalizeMessageIDForLookup(id)] = [] }
+
+        var queried: Set<String> = []
+        for id in messageIds {
+            let normalized = normalizeMessageIDForLookup(id)
+            guard queried.insert(normalized).inserted else { continue }
+            if let accountUUIDs, accountUUIDs.isEmpty { continue }
+
+            // `findMessage` filters `m.deleted = 0` and matches both bracketed and bare stored
+            // forms via `messageIDCandidates`. UNION them rather than stop at the first that
+            // answers — two accounts can store the same id in different forms, and JXA (which
+            // matches Mail's normalized `messageId`) sees both; stopping early would hide a
+            // copy from the cross-account check below.
+            var rows: [[String: Any]] = []
+            var seenRowIDs: Set<Int64> = []
+            for candidate in messageIDCandidates(id) {
+                for row in try index.findMessage(messageIDHeader: candidate) {
+                    guard let rowid = row["rowid"] as? Int64,
+                          seenRowIDs.insert(rowid).inserted else { continue }
+                    rows.append(row)
+                }
+            }
+
+            var refs: [ResolvedRef] = []
+            for row in rows {
+                guard let rowid = row["rowid"] as? Int64,
+                      let url = row["mailbox_url"] as? String,
+                      let mailboxRef = mailboxRef(forURL: url) else { continue }
+                // "On My Mac" mailboxes (`local://`, and `file://` for a mailbox addressed by
+                // its on-disk location — `accounts()` above skips both for the same reason)
+                // hang off the APPLICATION, not an account: Mail's scripting dictionary
+                // declares `account` and its POP / IMAP / iCloud subclasses and no local one,
+                // while `application` carries its own `mailbox` element. A `file://` URL has no
+                // account authority at all, so its rows would also share one empty account
+                // UUID. Every JXA lookup here goes through `Mail.accounts()` — the
+                // byId arm resolves a candidate's account before touching it, and all three
+                // sweeps of the scan enumerate `accounts[a].mailboxes` — so a local candidate
+                // is unreachable by construction. Skipping it keeps the candidate set faithful
+                // to what JXA can see: a local-only id resolves to nothing (the same
+                // fall-through as today, minus a wasted round trip), and a copy filed to On My
+                // Mac no longer makes an otherwise single-account id look cross-account and
+                // lose acceleration below.
+                if mailboxRef.scheme == "local" || mailboxRef.scheme == "file" { continue }
+                if let accountUUIDs, !accountUUIDs.contains(mailboxRef.accountUUID) { continue }
+                let names = index.accountNames()[mailboxRef.accountUUID]
+                refs.append(ResolvedRef(
+                    normalizedMessageId: normalized,
+                    rowid: rowid,
+                    mailboxURL: url,
+                    mailboxName: mailboxRef.name,
+                    mailboxPathComponents: mailboxRef.pathComponents,
+                    accountUUID: mailboxRef.accountUUID,
+                    accountName: names?.name))
+            }
+
+            // A Message-ID spanning more than one ACCOUNT is not accelerated. Order decides
+            // WHICH PHYSICAL COPY a write acts on, and both drift guards are blind to a wrong
+            // pick — both copies carry the same Message-ID.
+            //
+            // v3.11 is account-OUTER (exhausts one account's priority list before the next);
+            // reproducing that needs Mail's account order, which the Envelope Index does not
+            // carry. So this declines to an empty list and lets the account-outer scan pick, as
+            // today. `--account` is a hard filter above, so a scoped write stays accelerated.
+            if Set(refs.map { $0.accountUUID ?? "" }).count > 1 {
+                candidateMap[normalized] = []
+                continue
+            }
+
+            // `findMessage` orders by date_received; re-rank into the sweep's own order.
+            let ranked = refs.sorted { a, b in
+                if let mailbox {
+                    let aHit = a.mailboxName.caseInsensitiveCompare(mailbox) == .orderedSame
+                    let bHit = b.mailboxName.caseInsensitiveCompare(mailbox) == .orderedSame
+                    if aHit != bHit { return aHit }
+                }
+                let aRank = priorityRank(forMailboxName: a.mailboxName)
+                let bRank = priorityRank(forMailboxName: b.mailboxName)
+                if aRank != bRank { return aRank < bRank }
+                return a.rowid < b.rowid
+            }
+
+            // The same rule one level down: inside the one surviving account the order is
+            // still selection, so a CONTESTED id is accelerated only when this list's head is
+            // the copy the scan itself reaches first. See `headMatchesJXASweep`.
+            guard headMatchesJXASweep(ranked, mailboxHint: mailbox) else {
+                candidateMap[normalized] = []
+                continue
+            }
+
+            // HEAD ONLY: the guard certifies `ranked[0]` alone. The JXA candidate loop falls
+            // through a candidate on three normal paths — the account will not resolve, it
+            // exposes no mailbox to address the rowid through, and Layer-1 messageId mismatch
+            // — so a tail entry could land the write on a copy no guard certified. Costs
+            // nothing real: the tail only ever bought speed on a stale head, and a head miss
+            // falls through to the JXA scan (v3.11).
+            candidateMap[normalized] = Array(ranked.prefix(1))
+        }
+
+        return candidateMap
+    }
+}
+
+/// True when `ranked`'s head is the copy v3.11's own within-account scan reaches first. Emits
+/// the head alone, so certifying it is exactly certifying the whole list.
+///
+/// Rests on three properties of Mail's own scan. Two were observed directly on macOS 26.5 /
+/// Mail 16.0: `account.mailboxes()` is FLAT on every account type to hand (Gmail's special
+/// mailboxes come back as renamed top-level leaves, with no "[Gmail]" container), and
+/// `whose({name: …})` FOLDS CASE (`{name: 'inbox'}` matches INBOX). The third — what order
+/// `account.mailboxes()` enumerates copies the priority list cannot separate — is open. The
+/// rule assumes none of the three, because an account whose server files mailboxes under a
+/// parent is reachable on another machine: the head is trusted only when it is a DIRECT CHILD
+/// (so nesting can neither help nor hurt it) and it wins against the whole tail under BOTH the
+/// exact and case-folding readings — a proof against those two readings, not against any
+/// conceivable semantics. Everything else declines to an empty list and the scan decides, as
+/// today.
+///
+/// The direct-child requirement therefore declines a class it need not: a copy the index
+/// records under "[Gmail]/All Mail" is a top-level leaf to Mail, so the scan does reach it.
+/// Narrowing that means deciding when the index's server-side path may be read as Mail's own
+/// naming — a separate change, and one worth making only for CONTESTED ids, which the Gmail
+/// hot path is not.
+///
+/// A single deep candidate is NOT declined (the carried-labels Gmail case, which is the
+/// everyday write this accelerates) — with one copy there is no selection to get wrong.
+private func headMatchesJXASweep(_ ranked: [ResolvedRef], mailboxHint: String?) -> Bool {
+    guard ranked.count > 1 else { return true }
+    let head = ranked[0]
+    let tail = ranked.dropFirst()
+
+    guard head.mailboxPathComponents.count == 1 else { return false }
+
+    if let hint = mailboxHint,
+       head.mailboxName.caseInsensitiveCompare(hint) == .orderedSame {
+        // The hint loop runs before the priority sweep, so a hinted head wins there — but only
+        // if Mail's specifier matches the same string this sort matched. The sort above
+        // compares the hint case-insensitively (`--mailbox inbox` behaves like `--mailbox
+        // INBOX`, as `resolveMailboxes` does on the read side) while Mail's own
+        // `whose({name:…})` is a separate implementation, so the hint is trusted only on an
+        // EXACT match — which holds whether or not that specifier folds case — and only when
+        // no other candidate answers to it either way.
+        return head.mailboxName == hint
+            && tail.allSatisfy { $0.mailboxName.caseInsensitiveCompare(hint) != .orderedSame }
+    }
+
+    // No hint: the priority sweep decides. The head (a direct child) is reached at
+    // `priorityRank`/`priorityRankFoldingCase`; a tail candidate's earliest possible reach is
+    // the same rank under the same reading (nesting only delays it). So certification needs a
+    // strict win against the MINIMUM of the whole tail under BOTH readings — not the runner-up,
+    // since folding can promote a later element ahead of it (example:
+    // `[Archive(4), Receipts(unranked), Inbox(folds to 0)]`).
+    let headExact = priorityRank(forMailboxName: head.mailboxName)
+    let headFolding = priorityRankFoldingCase(forMailboxName: head.mailboxName)
+    let tailExact = tail.map { priorityRank(forMailboxName: $0.mailboxName) }.min() ?? Int.max
+    let tailFolding = tail.map { priorityRankFoldingCase(forMailboxName: $0.mailboxName) }
+        .min() ?? Int.max
+
+    return headExact < tailExact && headFolding < tailFolding
 }

--- a/swift/Tests/MailCLITests/MessageLocatorTests.swift
+++ b/swift/Tests/MailCLITests/MessageLocatorTests.swift
@@ -1,0 +1,993 @@
+import Foundation
+import SQLite3
+import XCTest
+@testable import MailCLI
+
+/// Cover for the write-path message locator: Message-ID -> ranked Envelope-Index ROWID
+/// candidates, and the JS those candidates are emitted as. Runs against a throwaway Envelope
+/// Index (no Mail.app, FDA, or `osascript`). Fixture harness duplicated from
+/// `EnvelopeIndexLabelsTests` (its `openFixture` is private) rather than shared.
+final class MessageLocatorTests: XCTestCase {
+
+    // Fixture mailbox ROWIDs.
+    private let allMailRowID: Int64 = 1    // imap://GMAIL-ACCOUNT/[Gmail]/All Mail  (nested)
+    private let inboxRowID: Int64 = 2      // imap://GMAIL-ACCOUNT/INBOX
+    private let otherInboxRowID: Int64 = 3 // ews://OTHER-ACCOUNT/Inbox
+    private let trashRowID: Int64 = 4      // imap://GMAIL-ACCOUNT/[Gmail]/Trash  (nested)
+    private let receiptsRowID: Int64 = 6   // imap://GMAIL-ACCOUNT/Receipts   (top-level, unranked)
+    private let oldMailRowID: Int64 = 7    // imap://GMAIL-ACCOUNT/Old Mail   (top-level, unranked)
+
+    private let gmailAccount = "GMAIL-ACCOUNT"
+    private let otherAccount = "OTHER-ACCOUNT"
+
+    private lazy var tempDir: URL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("mailcli-locator-\(UUID().uuidString)")
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - The Gmail assertion
+
+    func testGmailAllMailCandidateCarriesTheLeafNameAndThePathComponents() throws {
+        // THE regression this port exists to avoid. The old branch emitted Foundation's
+        // `URL.path` minus its leading slash — the FULL path, "[Gmail]/All Mail". JXA's
+        // mailbox `name` is the LEAF, so that string matched no mailbox, every Gmail
+        // candidate was skipped, and the acceleration silently no-opped (right answer,
+        // zero speedup) on the exact account type this fork targets.
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(
+            messageIds: ["<gmail-only@example.com>"], mailbox: nil, account: nil)
+
+        let candidates = try XCTUnwrap(refs["gmail-only@example.com"])
+        XCTAssertEqual(candidates.count, 1)
+        let candidate = try XCTUnwrap(candidates.first)
+
+        XCTAssertEqual(candidate.mailboxName, "All Mail")
+        XCTAssertEqual(candidate.mailboxPathComponents, ["[Gmail]", "All Mail"])
+        XCTAssertEqual(candidate.rowid, 201)
+        XCTAssertEqual(candidate.accountUUID, gmailAccount)
+
+        // Negative: the joined form must appear in no field the JXA side reads.
+        XCTAssertNotEqual(candidate.mailboxName, "[Gmail]/All Mail")
+        XCTAssertFalse(candidate.mailboxPathComponents.contains("[Gmail]/All Mail"))
+    }
+
+    // MARK: - Physical-vs-logical mailbox
+
+    func testLocatorResolvesToThePHYSICALMailboxNotTheLogicalOne() throws {
+        // Pins the write path to the PHYSICAL mailbox (on-disk store), not the logical one a
+        // Gmail label displays it under — see `SQLiteEngine.mailboxRef(forURL:)`. The fixture
+        // makes the two genuinely differ so this isn't vacuous: message 201 is stored under
+        // [Gmail]/All Mail but labeled INBOX.
+        let engine = try SQLiteEngine(index: try openFixture(extraSQL: Self.gmailLabelRows))
+
+        // Half 1 — the divergence is real and observable, not a premise this test asserts of
+        // itself. The READ path, scoped to INBOX, reports this very message as living in
+        // "INBOX": that is `mailboxRef(forRow:)` preferring `logical_mailbox_rowid`. Without
+        // this half, half 2 would pass on a fixture where the two never differed and would
+        // pin nothing.
+        let read = try engine.search(query: "Fixture subject", field: "subject",
+                                     mailbox: "INBOX", account: nil, limit: 50, since: nil)
+        let readMessages = try XCTUnwrap(read["messages"] as? [[String: Any]])
+        let readRow = try XCTUnwrap(readMessages.first {
+            $0["messageId"] as? String == "gmail-only@example.com"
+        })
+        XCTAssertEqual(readRow["mailbox"] as? String, "INBOX")
+
+        // Half 2 — the locator, on the same message in the same database, reports the
+        // PHYSICAL mailbox.
+        let refs = try engine.resolve(
+            messageIds: ["<gmail-only@example.com>"], mailbox: nil, account: nil)
+        let candidate = try XCTUnwrap(refs["gmail-only@example.com"]?.first)
+        XCTAssertEqual(candidate.rowid, 201)
+        XCTAssertEqual(candidate.mailboxURL, "imap://GMAIL-ACCOUNT/%5BGmail%5D/All%20Mail")
+        XCTAssertEqual(candidate.mailboxName, "All Mail")
+        XCTAssertEqual(candidate.mailboxPathComponents, ["[Gmail]", "All Mail"])
+
+        // Negative: no field the JXA side reads may name the logical mailbox.
+        XCTAssertNotEqual(candidate.mailboxName, "INBOX")
+        XCTAssertFalse(candidate.mailboxPathComponents.contains("INBOX"))
+        XCTAssertNotEqual(candidate.mailboxURL, "imap://GMAIL-ACCOUNT/INBOX")
+
+        // Scope of the check, stated so a later reader does not over-read it: today
+        // `findMessage` — the locator's only row source — does not project
+        // `logical_mailbox_rowid` at all, so swapping this call to `mailboxRef(forRow:)` would
+        // not by itself redden this test. What it catches is the change that makes the hazard
+        // live: routing `resolve` through a mailbox-scoped query, whose rows DO carry the
+        // logical value (half 1 is that query).
+    }
+
+    func testEmittedJSCarriesNoMailboxPathForJXAToMatchOn() throws {
+        // The JXA side addresses a candidate by account + rowid and never by mailbox name, so
+        // the server-side path stays on the Swift side (`headMatchesJXASweep` reads it) and
+        // never reaches the script. Asserted on the string that actually reaches JXA, because
+        // shipping a path is what invites a name compare back in: `[Gmail]` is Mail's
+        // server-side container, and JXA's own mailbox list has no such entry to match it.
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(
+            messageIds: ["<gmail-only@example.com>"], mailbox: nil, account: nil)
+        let js = buildRowidMapJS(refs)
+
+        XCTAssertFalse(js.contains("[Gmail]"))
+        XCTAssertFalse(js.contains("\"path\""), "no path key may be emitted")
+
+        let map = try parseRowidMap(js)
+        let entry = try XCTUnwrap(map["gmail-only@example.com"]?.first)
+        // The leaf name stays: it is the per-message lookup telemetry's "where SQLite said this
+        // copy lives", never an argument to a Mail lookup.
+        XCTAssertEqual(entry["mb"] as? String, "All Mail")
+        XCTAssertNil(entry["path"])
+    }
+
+    // MARK: - Message-ID forms
+
+    func testBracketedAndBareRequestsBothResolve() throws {
+        let engine = try openFixtureEngine()
+        for requested in ["<gmail-only@example.com>", "gmail-only@example.com"] {
+            let refs = try engine.resolve(messageIds: [requested], mailbox: nil, account: nil)
+            XCTAssertEqual(refs["gmail-only@example.com"]?.count, 1,
+                           "request form \(requested) must resolve")
+        }
+    }
+
+    func testAHeaderStoredWithoutAngleBracketsStillResolves() throws {
+        // The old locator bound only "<\(id)>", so any bare-stored header missed and the
+        // command fell back to the slow scan silently. `messageIDCandidates` tries both.
+        let engine = try openFixtureEngine()
+        for requested in ["<bare@example.com>", "bare@example.com"] {
+            let refs = try engine.resolve(messageIds: [requested], mailbox: nil, account: nil)
+            XCTAssertEqual(refs["bare@example.com"]?.first?.rowid, 204,
+                           "request form \(requested) must resolve a bare-stored header")
+        }
+    }
+
+    func testNormalizeMessageIDForLookupTrimsThenStripsBrackets() throws {
+        // Must agree with the JS twin emitted into every script, or the JXA side looks the
+        // candidate list up under a key that is not there.
+        XCTAssertEqual(normalizeMessageIDForLookup("  <a@b>  "), "a@b")
+        XCTAssertEqual(normalizeMessageIDForLookup("<a@b>"), "a@b")
+        XCTAssertEqual(normalizeMessageIDForLookup("a@b"), "a@b")
+        XCTAssertEqual(normalizeMessageIDForLookup(" a@b "), "a@b")
+    }
+
+    // MARK: - Batch contract
+
+    func testEveryRequestedIdIsAKeyIncludingOnesThatResolveToNothing() throws {
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(
+            messageIds: ["<gmail-only@example.com>", "<nope@example.com>", "<multi@example.com>"],
+            mailbox: nil, account: nil)
+
+        XCTAssertEqual(Set(refs.keys),
+                       ["gmail-only@example.com", "nope@example.com", "multi@example.com"])
+        XCTAssertEqual(refs["nope@example.com"]?.isEmpty, true)
+    }
+
+    // MARK: - Account hard filter
+
+    func testAccountFilterNarrowsCandidatesToThatAccount() throws {
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(
+            messageIds: ["<gmail-only@example.com>", "<other-acct@example.com>"],
+            mailbox: nil, account: otherAccount)
+
+        XCTAssertEqual(refs["gmail-only@example.com"]?.isEmpty, true)
+        XCTAssertEqual(refs["other-acct@example.com"]?.count, 1)
+        XCTAssertEqual(refs["other-acct@example.com"]?.first?.accountUUID, otherAccount)
+    }
+
+    func testUnresolvableAccountYieldsEmptyCandidatesAndDoesNotThrow() throws {
+        // `resolveMailboxes` throws .notFound on an unknown account. A write-path locator
+        // must not: under `--engine auto` the JXA scan still runs with its own acctHint and
+        // also finds nothing, so the two engines agree. Throwing would fail the write.
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(
+            messageIds: ["<gmail-only@example.com>"], mailbox: nil,
+            account: "no-such-account-4C2F")
+
+        XCTAssertEqual(refs["gmail-only@example.com"]?.isEmpty, true)
+    }
+
+    func testAnAMBIGUOUSAccountHintFailsOPENToEmptyCandidates() throws {
+        // The other account-hint failure: `accountUUIDs(matching:)` THROWS `.ambiguous` for a
+        // name spanning two logical accounts. A write must not inherit that (JXA still
+        // completes the write under `--engine auto`), so `resolve`'s `try?` fails OPEN. Every
+        // other fixture leaves the throw unreachable; this one reaches it.
+        let index = try openFixture(accountsSQL: Self.sharedUsernameAccountRows)
+
+        // Precondition: the throw actually fires here. Without it this test's outcome is
+        // indistinguishable from `testUnresolvableAccountYieldsEmptyCandidatesAndDoesNotThrow`
+        // above — an account that merely matched nothing — and the swallow would still be
+        // untested.
+        XCTAssertThrowsError(try index.accountUUIDs(matching: "shared@example.com")) { error in
+            guard case EnvelopeIndexError.ambiguous(let message) = error else {
+                return XCTFail("fixture precondition: expected .ambiguous, got \(error)")
+            }
+            XCTAssertTrue(message.contains("multiple logical accounts"))
+        }
+
+        let engine = try SQLiteEngine(index: index)
+
+        // Control, same database, same seam: an UNAMBIGUOUS hint still resolves. This is what
+        // separates "the swallow fired" from "the accounts store never loaded" — an unwired
+        // seam would empty this arm too.
+        let unambiguous = try engine.resolve(
+            messageIds: ["<gmail-only@example.com>"], mailbox: nil, account: "Shared A")
+        XCTAssertEqual(unambiguous["gmail-only@example.com"]?.count, 1)
+        XCTAssertEqual(unambiguous["gmail-only@example.com"]?.first?.accountUUID, gmailAccount)
+
+        // The fail-open. A throw out of `resolve` fails this test outright (it propagates);
+        // what is asserted is the shape the comment promises — every requested id still a key,
+        // every one carrying an empty candidate list, including ids in BOTH of the accounts the
+        // ambiguous username spans.
+        let refs = try engine.resolve(
+            messageIds: ["<gmail-only@example.com>", "<other-acct@example.com>",
+                         "<nope@example.com>"],
+            mailbox: nil, account: "shared@example.com")
+
+        XCTAssertEqual(Set(refs.keys),
+                       ["gmail-only@example.com", "other-acct@example.com", "nope@example.com"])
+        for (id, candidates) in refs {
+            XCTAssertTrue(candidates.isEmpty, "\(id) must resolve to no candidates")
+        }
+
+        // And the same thing as JXA sees it: the comment's claim is about `lookup.candidates`,
+        // which the JS side reads off this map. Every array empty is `candidates.length === 0`
+        // for every id, so the `whose` scan makes every selection — v3.11's behaviour exactly.
+        let map = try parseRowidMap(buildRowidMapJS(refs))
+        XCTAssertEqual(Set(map.keys),
+                       ["gmail-only@example.com", "other-acct@example.com", "nope@example.com"])
+        for (id, entries) in map {
+            XCTAssertTrue(entries.isEmpty, "\(id) must reach JXA with an empty candidate array")
+        }
+    }
+
+    // MARK: - Candidate ordering
+
+    func testPriorityRankSelectsInboxOverTrashRegardlessOfRowOrder() throws {
+        // `findMessage` returns date_received DESC, and the Trash copy is the newer one
+        // (rowid 202), so trusting row order would select Trash. INBOX (rowid 203) is
+        // top-level with a strictly better rank under both readings of the by-name specifier,
+        // so it is certified and it is the ONLY candidate emitted.
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(messageIds: ["<multi@example.com>"], mailbox: nil, account: nil)
+        let candidates = try XCTUnwrap(refs["multi@example.com"])
+
+        XCTAssertEqual(candidates.map { $0.mailboxName }, ["INBOX"])
+        XCTAssertEqual(candidates.first?.rowid, 203)
+    }
+
+    func testMailboxHintOutranksThePriorityList() throws {
+        // The hinted copy is TOP-LEVEL, so v3.11's `mailboxes.whose({name: 'Receipts'})` loop
+        // reaches it, and that loop runs before the priority sweep — INBOX's rank 0 does not
+        // get to decide. `Receipts` carries no priority entry, so nothing but the hint could
+        // select it.
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(
+            messageIds: ["<hinted@example.com>"], mailbox: "Receipts", account: nil)
+        let candidates = try XCTUnwrap(refs["hinted@example.com"])
+
+        XCTAssertEqual(candidates.map { $0.mailboxName }, ["Receipts"])
+        XCTAssertEqual(candidates.first?.rowid, 216)
+    }
+
+    func testACaseFoldedHintDoesNotDecideBetweenTWOCopies() throws {
+        // The Swift hint compare is case-insensitive while Mail's own `whose({name:…})` is a
+        // separate implementation of the same idea (it folded case when probed on macOS 26.5,
+        // which is not a guarantee across versions). A case-folded hint is therefore not
+        // provably the thing that decides in v3.11, so the head is not provably the scan's own
+        // pick — decline rather than guess. Same id, same mailboxes as the test above; only
+        // the hint's case differs, which is the whole discrimination.
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(
+            messageIds: ["<hinted@example.com>"], mailbox: "receipts", account: nil)
+
+        XCTAssertEqual(refs["hinted@example.com"]?.isEmpty, true)
+    }
+
+    func testAHintTwoCopiesBothAnswerToDoesNotSelectBetweenThem() throws {
+        // Top-level `Trash` and the index's `[Gmail]/Trash` share a leaf name, so `--mailbox
+        // Trash` matches both and the hint stops discriminating. v3.11's hint loop returns
+        // whichever ones its specifier reaches, in an order that is Mail's — so the head here
+        // is the scan's own pick only under one reading of how Mail presents that second copy.
+        let index = try openFixture()
+        XCTAssertEqual(try index.findMessage(messageIDHeader: "<two-trashes@example.com>").count, 2,
+                       "fixture precondition: both copies must be present, or the decline is vacuous")
+
+        let refs = try SQLiteEngine(index: index).resolve(
+            messageIds: ["<two-trashes@example.com>"], mailbox: "Trash", account: nil)
+
+        XCTAssertEqual(refs["two-trashes@example.com"]?.isEmpty, true)
+    }
+
+    func testAHintNoCopyAnswersToLeavesThePriorityOrderInCharge() throws {
+        // The hint is not a filter: matching nothing must fall through to the priority sweep,
+        // not decline. INBOX is still the certified head and the id stays accelerated.
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(
+            messageIds: ["<multi@example.com>"], mailbox: "No Such Mailbox", account: nil)
+        let candidates = try XCTUnwrap(refs["multi@example.com"])
+
+        XCTAssertEqual(candidates.map { $0.mailboxName }, ["INBOX"])
+    }
+
+    func testAHintMatchingANestedLeafDeclinesInsteadOfPromotingThatCopy() throws {
+        // The hint matches LEAF names, so "All Mail" promotes the copy the index files under a
+        // parent — and whether v3.11's by-name specifier reaches that copy first depends on how
+        // Mail presents it (flat on every account probed, nested in principle — issue #67).
+        // Declines rather than guess. Also pins leaf- vs joined-path comparison: joined, the
+        // hint would match nothing and this would resolve two candidates instead of none.
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(
+            messageIds: ["<in-both@example.com>"], mailbox: "All Mail", account: nil)
+
+        XCTAssertEqual(refs["in-both@example.com"]?.isEmpty, true)
+    }
+
+    // MARK: - Within-account copy selection
+
+    func testANestedCopyOutrankingATopLevelOneIsNotAccelerated() throws {
+        // Order is selection within one account too. `[Gmail]/Trash` ranks 9, top-level
+        // `Receipts` is unranked, so leaf-name ranking heads the list with the deeper copy —
+        // but v3.11's sweep reaches it at rank 9 only if Mail presents it as a top-level
+        // `Trash`; if it is a child, the by-name specifier may not reach it at all (issue #67)
+        // and the sweep finds it last. Declines rather than guess.
+        let index = try openFixture()
+        XCTAssertEqual(try index.findMessage(messageIDHeader: "<nested-outranks@example.com>").count, 2,
+                       "fixture precondition: both copies must be present, or the decline is vacuous")
+
+        let refs = try SQLiteEngine(index: index).resolve(
+            messageIds: ["<nested-outranks@example.com>"], mailbox: nil, account: nil)
+
+        XCTAssertEqual(refs["nested-outranks@example.com"]?.isEmpty, true)
+    }
+
+    func testTwoCopiesThePriorityListCannotSeparateAreNotAccelerated() throws {
+        // Both top-level, both unranked, so v3.11 reaches neither through the priority sweep:
+        // both fall to the final `account.mailboxes()` loop, whose enumeration order is Mail's
+        // and is not in the Envelope Index. Ranking them by rowid would be an invention.
+        let index = try openFixture()
+        XCTAssertEqual(try index.findMessage(messageIDHeader: "<two-unranked@example.com>").count, 2,
+                       "fixture precondition: both copies must be present, or the decline is vacuous")
+
+        let refs = try SQLiteEngine(index: index).resolve(
+            messageIds: ["<two-unranked@example.com>"], mailbox: nil, account: nil)
+
+        XCTAssertEqual(refs["two-unranked@example.com"]?.isEmpty, true)
+    }
+
+    func testACaseVariantOfAPriorityNameIsNotOutrankedByALowerEntry() throws {
+        // AppleScript's default string compare FOLDS CASE. `Archive` (rank 4 exact) beats
+        // unranked `Inbox` under the exact compare, but a folding `whose({name:'INBOX'})` at
+        // p=0 reaches Inbox first — so v3.11 could destroy a different copy while both drift
+        // guards pass (same Message-ID). EWS names its inbox `Inbox`, so this is real, not
+        // contrived.
+        let index = try openFixture()
+        XCTAssertEqual(try index.findMessage(messageIDHeader: "<case-variant@example.com>").count, 2,
+                       "fixture precondition: both copies must be present, or the decline is vacuous")
+
+        let refs = try SQLiteEngine(index: index).resolve(
+            messageIds: ["<case-variant@example.com>"], mailbox: nil, account: nil)
+
+        XCTAssertEqual(refs["case-variant@example.com"]?.isEmpty, true)
+    }
+
+    func testTheCaseFoldedRankIsCheckedAgainstTHEWHOLETAILNotTheRunnerUp() throws {
+        // The list is sorted by the EXACT rank, so `ranked[1]` is the tail's best under that
+        // reading ONLY. Three direct children of one account: `Archive` (exact 4, folding 4),
+        // `Receipts` (unranked either way, lower message rowid so it sorts second) and `Inbox`
+        // (exact unranked, folding 0). A runner-up-only check compares Archive against
+        // Receipts, wins under both readings, and certifies Archive — while a case-folding
+        // sweep reaches the `Inbox` copy at p=0, before Archive at p=4. Only a strict win
+        // against the MINIMUM over the whole tail declines this.
+        let index = try openFixture()
+        XCTAssertEqual(try index.findMessage(messageIDHeader: "<three-way@example.com>").count, 3,
+                       "fixture precondition: all three copies must be present, or this is vacuous")
+
+        let refs = try SQLiteEngine(index: index).resolve(
+            messageIds: ["<three-way@example.com>"], mailbox: nil, account: nil)
+
+        XCTAssertEqual(refs["three-way@example.com"]?.isEmpty, true)
+    }
+
+    func testTwoCopiesInTheSAMEMailboxAreNotAccelerated() throws {
+        // Two rows in ONE mailbox is the shape the ranking cannot separate, named rather than
+        // left to be re-derived: they share a mailbox URL, hence a leaf name, hence a rank, so
+        // the priority arm's strict win is unsatisfiable and the hint arm's "no other candidate
+        // answers to this hint" clause fails too. Both arms are asserted, because with a hint
+        // the decline comes from the other one. (Which copy `byId` would have returned is not
+        // the question — it addresses one ROWID and Layer 1 re-verifies what comes back; the
+        // question is whether our order is the scan's, and here nothing can establish that.)
+        let index = try openFixture()
+        XCTAssertEqual(try index.findMessage(messageIDHeader: "<same-mailbox-twice@example.com>").count, 2,
+                       "fixture precondition: both rows must be present, or the decline is vacuous")
+        let engine = try SQLiteEngine(index: index)
+
+        let noHint = try engine.resolve(
+            messageIds: ["<same-mailbox-twice@example.com>"], mailbox: nil, account: nil)
+        XCTAssertEqual(noHint["same-mailbox-twice@example.com"]?.isEmpty, true)
+
+        let hinted = try engine.resolve(
+            messageIds: ["<same-mailbox-twice@example.com>"], mailbox: "Inbox", account: nil)
+        XCTAssertEqual(hinted["same-mailbox-twice@example.com"]?.isEmpty, true)
+    }
+
+    func testAPercentEncodedEWSSpecialFolderIsRankedByItsDECODEDName() throws {
+        // Exchange stores its special folders with spaces, which the mailbox URL carries
+        // percent-encoded (`Sent%20Items`). Ranking happens on the DECODED leaf, so a decode
+        // regression would not merely rename the candidate: `Sent%20Items` matches no
+        // `mailboxPriority` entry, the head would score unranked against `Archive`'s 4, the
+        // strict win would fail and this id would silently stop being accelerated. The rank
+        // assertion is the half that makes the certification depend on the decode.
+        XCTAssertLessThan(priorityRank(forMailboxName: "Sent Items"),
+                          priorityRank(forMailboxName: "Archive"))
+
+        let index = try openFixture()
+        XCTAssertEqual(try index.findMessage(messageIDHeader: "<pct-encoded-head@example.com>").count, 2,
+                       "fixture precondition: both copies must be present, or this is vacuous")
+
+        let refs = try SQLiteEngine(index: index).resolve(
+            messageIds: ["<pct-encoded-head@example.com>"], mailbox: nil, account: nil)
+
+        let candidates = try XCTUnwrap(refs["pct-encoded-head@example.com"])
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(candidates.first?.mailboxName, "Sent Items")
+        XCTAssertEqual(candidates.first?.rowid, 233, "the Sent Items copy, not the Archive one")
+    }
+
+    func testACertifiedContestedIdEmitsTheCERTIFIEDHEADALONE() throws {
+        // The guard certifies `ranked[0]` and nothing else, but the emitted candidate loop does
+        // not stop at the head: it `continue`s past a candidate when the account will not
+        // resolve, when that account exposes no mailbox to address the rowid through, and when
+        // Layer 1 sees a messageId mismatch. Any of those would land the write on an
+        // UNCERTIFIED tail copy, so a certified contested id emits the head alone and a head
+        // miss falls to the JXA scan.
+        let index = try openFixture()
+        XCTAssertEqual(try index.findMessage(messageIDHeader: "<in-both@example.com>").count, 2,
+                       "fixture precondition: two copies, or 'head alone' is indistinguishable")
+
+        let refs = try SQLiteEngine(index: index).resolve(
+            messageIds: ["<in-both@example.com>"], mailbox: nil, account: nil)
+        let candidates = try XCTUnwrap(refs["in-both@example.com"])
+
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(candidates.first?.mailboxName, "INBOX")
+        XCTAssertEqual(candidates.first?.rowid, 208)
+    }
+
+    func testASINGLENestedCopyStaysAccelerated() throws {
+        // Counterweight to the two nested-copy declines above: one candidate is no selection
+        // to get wrong, and under the carried-labels model this IS the everyday Gmail write
+        // (one physical copy under [Gmail]/All Mail, INBOX via `labels`). Declining every
+        // nested candidate would turn the acceleration off for the account type this port
+        // targets. A deliberate reachability change — Layer 1 still re-verifies before the
+        // write.
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(
+            messageIds: ["<gmail-only@example.com>"], mailbox: nil, account: nil)
+        let candidates = try XCTUnwrap(refs["gmail-only@example.com"])
+
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(candidates.first?.mailboxPathComponents, ["[Gmail]", "All Mail"])
+    }
+
+    // MARK: - On My Mac (local://) mailboxes
+
+    func testALocalCopyNeitherWinsNorBlocksAccelerationOfTheServerCopy() throws {
+        // Mail's scripting dictionary declares `account` with POP / IMAP / iCloud subclasses
+        // and no local one; On My Mac mailboxes are an element of the APPLICATION. Every JXA
+        // lookup on both arms goes through `Mail.accounts()`, so the local copy is invisible
+        // to it. Counted, it would make this single-account id look cross-account and decline
+        // acceleration for a copy JXA can never act on.
+        let index = try openFixture()
+        XCTAssertEqual(try index.findMessage(messageIDHeader: "<local-and-server@example.com>").count, 2,
+                       "fixture precondition: both copies must be present, or this is vacuous")
+
+        let refs = try SQLiteEngine(index: index).resolve(
+            messageIds: ["<local-and-server@example.com>"], mailbox: nil, account: nil)
+
+        let candidates = try XCTUnwrap(refs["local-and-server@example.com"])
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(candidates.first?.rowid, 229, "the imap INBOX copy, not the On My Mac one")
+        XCTAssertEqual(candidates.first?.accountUUID, "GMAIL-ACCOUNT")
+    }
+
+    func testAnIdThatOnlyExistsOnMyMacResolvesToNothing() throws {
+        // No candidate rather than one JXA cannot resolve: the fast path is skipped and the
+        // `whose` scan runs exactly as it does today, minus a wasted account round trip.
+        let index = try openFixture()
+        XCTAssertEqual(try index.findMessage(messageIDHeader: "<local-only@example.com>").count, 1,
+                       "fixture precondition: the local row must be present, or this is vacuous")
+
+        let refs = try SQLiteEngine(index: index).resolve(
+            messageIds: ["<local-only@example.com>"], mailbox: nil, account: nil)
+
+        XCTAssertEqual(refs["local-only@example.com"]?.isEmpty, true)
+    }
+
+    func testAFileURLCopyNeitherWinsNorBlocksAccelerationOfTheServerCopy() throws {
+        // `file://` is the other scheme with no account behind it — `SQLiteEngine.accounts()`
+        // skips `local` and `file` side by side for that reason — and it is the worse of the
+        // two here: its URL has no account authority at all, so every `file://` row shares one
+        // empty account UUID. Counted, it both adds a candidate JXA cannot reach and makes a
+        // single-account id look cross-account, declining acceleration outright.
+        let index = try openFixture()
+        XCTAssertEqual(try index.findMessage(messageIDHeader: "<file-and-server@example.com>").count, 2,
+                       "fixture precondition: both copies must be present, or this is vacuous")
+
+        let refs = try SQLiteEngine(index: index).resolve(
+            messageIds: ["<file-and-server@example.com>"], mailbox: nil, account: nil)
+
+        let candidates = try XCTUnwrap(refs["file-and-server@example.com"])
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(candidates.first?.rowid, 236, "the imap INBOX copy, not the file:// one")
+        XCTAssertEqual(candidates.first?.accountUUID, "GMAIL-ACCOUNT")
+    }
+
+    func testAnIdThatOnlyExistsInAFileURLMailboxResolvesToNothing() throws {
+        // As with On My Mac: no candidate rather than one JXA cannot resolve.
+        let index = try openFixture()
+        XCTAssertEqual(try index.findMessage(messageIDHeader: "<file-only@example.com>").count, 1,
+                       "fixture precondition: the file:// row must be present, or this is vacuous")
+
+        let refs = try SQLiteEngine(index: index).resolve(
+            messageIds: ["<file-only@example.com>"], mailbox: nil, account: nil)
+
+        XCTAssertEqual(refs["file-only@example.com"]?.isEmpty, true)
+    }
+
+    // MARK: - Cross-account copy selection
+
+    func testAMessageIdPresentInTwoAccountsIsNotAcceleratedAtAll() throws {
+        // v3.11 is account-OUTER (exhausts one account before the next), so with the message
+        // in GMAIL/Trash and OTHER/INBOX it picks Gmail's copy. Ranking by priority alone would
+        // invert that and pick a different account's copy — undetectable to either drift guard
+        // (same Message-ID). SQLite can't know Mail's account order, so it declines instead.
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(
+            messageIds: ["<cross-acct@example.com>"], mailbox: nil, account: nil)
+
+        XCTAssertEqual(refs["cross-acct@example.com"]?.isEmpty, true)
+    }
+
+    func testDuplicatesWithinONEAccountAreStillAccelerated() throws {
+        // The decline above must not swallow every duplicate: two copies in one account stay
+        // accelerated when the head is what v3.11's scan reaches first (INBOX, rank 0). Fixture
+        // is a plain-IMAP shape, not Gmail's (see `testASINGLENestedCopyStaysAccelerated`).
+        // Asserts NOT-DECLINED only; which copy survives is
+        // `testACertifiedContestedIdEmitsTheCERTIFIEDHEADALONE`.
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(messageIds: ["<in-both@example.com>"], mailbox: nil, account: nil)
+        let candidates = try XCTUnwrap(refs["in-both@example.com"])
+
+        XCTAssertFalse(candidates.isEmpty)
+        XCTAssertEqual(Set(candidates.compactMap { $0.accountUUID }), [gmailAccount])
+    }
+
+    func testAnAccountFilterRestoresAccelerationForACrossAccountId() throws {
+        // `--account` is a hard filter applied before the count, so a scoped write is
+        // unambiguous about which account it means and keeps the fast path.
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(
+            messageIds: ["<cross-acct@example.com>"], mailbox: nil, account: gmailAccount)
+        let candidates = try XCTUnwrap(refs["cross-acct@example.com"])
+
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(candidates.first?.accountUUID, gmailAccount)
+        XCTAssertEqual(candidates.first?.mailboxName, "Trash")
+    }
+
+    func testCopiesStoredInDIFFERENTHEADERFORMSAreAllSeenBeforeTheDecision() throws {
+        // The decline above can only be as complete as the row set it counts. `findMessage`
+        // matches `message_id_header` EXACTLY, and the candidate loop used to stop at the
+        // first form that returned rows — so a Message-ID stored bracketed in one account
+        // and bare in another was seen as single-account, the guard passed, and the fast
+        // path picked one copy while JXA (which matches Mail's own normalized `messageId`
+        // property, not the stored bytes) would have seen both. `messageIDCandidates` exists
+        // because bare storage happens in the wild, so this is reachable, not theoretical.
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(messageIds: ["<mixed@example.com>"], mailbox: nil, account: nil)
+
+        XCTAssertEqual(refs["mixed@example.com"]?.isEmpty, true)
+    }
+
+    func testBothHeaderFormsAreUnionedNotShortCircuited() throws {
+        // Same union mechanism, both copies in one account: shows up as SELECTION, not a
+        // count. `messageIDCandidates` yields the bracketed form first, which alone would
+        // certify the wrong copy (rowid 213); unioning finds the bare-stored INBOX copy (214,
+        // outranks Trash), so the two rowids are what discriminate.
+        let index = try openFixture()
+        XCTAssertEqual(try index.findMessage(messageIDHeader: "<mixedsame@example.com>")
+                        .compactMap { $0["rowid"] as? Int64 }, [213],
+                       "precondition: the bracketed form alone resolves to the Trash copy, "
+                        + "which is what makes the unioned head a different physical copy")
+
+        let refs = try SQLiteEngine(index: index).resolve(
+            messageIds: ["mixedsame@example.com"], mailbox: nil, account: nil)
+        let candidates = try XCTUnwrap(refs["mixedsame@example.com"])
+
+        XCTAssertEqual(candidates.map { $0.mailboxName }, ["INBOX"])
+        XCTAssertEqual(candidates.first?.rowid, 214)
+    }
+
+    // MARK: - Deleted rows
+
+    func testATombstonedRowProducesNoCandidate() throws {
+        // `findMessage` filters m.deleted = 0. A deleted=1 ROWID is not addressable from
+        // JXA anyway, so the message takes the slow path rather than a doomed byId.
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(messageIds: ["<deleted@example.com>"], mailbox: nil, account: nil)
+
+        XCTAssertEqual(refs["deleted@example.com"]?.isEmpty, true)
+    }
+
+    // MARK: - buildRowidMapJS shape
+
+    func testRowidMapKeysAreBracketStrippedAndValuesAreCandidateArrays() throws {
+        // The JS contract is an ARRAY per id — the finder loops it — even though a contested id
+        // now contributes exactly one element (the certified head).
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(messageIds: ["<multi@example.com>"], mailbox: nil, account: nil)
+        let map = try parseRowidMap(buildRowidMapJS(refs))
+
+        XCTAssertEqual(Array(map.keys), ["multi@example.com"])
+        let entries = try XCTUnwrap(map["multi@example.com"])
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.map { $0["mb"] as? String }, ["INBOX"])
+        XCTAssertEqual(entries.first?["r"] as? Int64, 203)
+        XCTAssertEqual(entries.first?["acctId"] as? String, gmailAccount)
+    }
+
+    func testRowidMapOmitsAccountNameWhenTheAccountsStoreDoesNotKnowIt() throws {
+        // The fixture's account UUIDs are synthetic, so `accountNames()` has no entry and
+        // `acct` must be absent. `acctId` (matched against JXA `account.id()`) is the robust
+        // key; `acct` is only the fallback.
+        let engine = try openFixtureEngine()
+        let refs = try engine.resolve(messageIds: ["<gmail-only@example.com>"], mailbox: nil, account: nil)
+        let entry = try XCTUnwrap(try parseRowidMap(buildRowidMapJS(refs))["gmail-only@example.com"]?.first)
+
+        XCTAssertNotNil(entry["acctId"])
+        XCTAssertNil(entry["acct"])
+    }
+
+    func testEmptyResolutionEmitsAnEmptyObject() throws {
+        // The Full-Disk-Access-absent contract: an empty map means `candidates.length === 0`
+        // for every id, so the JXA `whose` scan runs exactly as it does today.
+        XCTAssertEqual(buildRowidMapJS([:]), "{}")
+    }
+
+    func testAnIdThatResolvedToNothingEmitsAnEmptyCandidateArray() throws {
+        let js = buildRowidMapJS(["a@b": []])
+        let map = try parseRowidMap(js)
+        XCTAssertEqual(map["a@b"]?.isEmpty, true)
+    }
+
+    // MARK: - The finder the write commands embed
+
+    func testTheWriteFinderSeamEmitsTheUnifiedFinderNotALegacyOne() throws {
+        // All five write commands build their `findMsg` through this one function. The legacy
+        // finders are still live on the read side and take the same hints, so a swap here
+        // would compile and would silently drop both the rowid fast path and the post-`byId`
+        // messageId verify that makes it safe. Asserting the seam is what stops that being
+        // invisible; `--engine jxa` is used so the assertion needs no Envelope Index.
+        let finder = try unifiedWriteFinderJXA(
+            for: ["<m@x>"], mailbox: nil, account: nil, engine: .jxa)
+
+        XCTAssertTrue(finder.contains("const rowidMap = {\"m@x\":[]};"),
+                      "the seam must emit the resolved rowid map")
+        XCTAssertTrue(finder.contains("mb.messages.byId(cand.r)"),
+                      "the seam must emit the rowid fast path")
+        XCTAssertTrue(finder.contains("normalizeMessageId(msg.messageId()) === normalized"),
+                      "the seam must emit the post-byId messageId verify")
+        XCTAssertTrue(finder.contains("function getLookupSummary()"),
+                      "the seam must emit the locator telemetry helper")
+        XCTAssertTrue(finder.contains("const _locatorBackend = 'jxa-only';"),
+                      "the seam must report the backend it actually built")
+    }
+
+    // MARK: - Noop locator / engine selection
+
+    func testJXAEngineBuildsANoopLocatorThatNeverResolvesAnything() throws {
+        let locator = try makeMessageLocator(engine: .jxa)
+        XCTAssertFalse(locator.isAvailable())
+
+        let refs = try locator.resolve(
+            messageIds: ["<a@b>", "c@d"], mailbox: "INBOX", account: "Anything")
+        XCTAssertEqual(Set(refs.keys), ["a@b", "c@d"])
+        XCTAssertEqual(refs["a@b"]?.isEmpty, true)
+        XCTAssertEqual(refs["c@d"]?.isEmpty, true)
+    }
+
+    func testJXAEngineResolutionReportsTheJXAOnlyBackend() throws {
+        // The backend label is what the acceptance evidence reads to tell "byId fast path
+        // working" from "silently falling back to the same slow scan".
+        let resolved = try resolveRowidMap(
+            for: ["<a@b>"], mailbox: nil, account: nil, engine: .jxa)
+        XCTAssertEqual(resolved.backend, "jxa-only")
+        XCTAssertEqual(try parseRowidMap(resolved.js)["a@b"]?.isEmpty, true)
+    }
+
+    // MARK: - Fixture
+
+    private func parseRowidMap(_ js: String) throws -> [String: [[String: Any]]] {
+        let data = try XCTUnwrap(js.data(using: .utf8))
+        let object = try JSONSerialization.jsonObject(with: data)
+        return try XCTUnwrap(object as? [String: [[String: Any]]])
+    }
+
+    private func openFixtureEngine() throws -> SQLiteEngine {
+        try SQLiteEngine(index: try openFixture())
+    }
+
+    /// Build a throwaway Envelope Index and open it through the production reader.
+    /// `extraSQL` is appended verbatim after the base schema and rows, for the one test that
+    /// needs a `labels` table the rest of the file deliberately does without. `accountsSQL`,
+    /// when given, builds an accounts store at the seam path below, for the one test that
+    /// needs `accountNames()` to answer with something.
+    private func openFixture(extraSQL: String = "",
+                             accountsSQL: String? = nil) throws -> EnvelopeIndex {
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let dbPath = tempDir.appendingPathComponent("Envelope Index")
+
+        var handle: OpaquePointer?
+        let openResult = sqlite3_open_v2(
+            dbPath.path, &handle, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil)
+        guard openResult == SQLITE_OK, let handle else {
+            if let handle { sqlite3_close_v2(handle) }
+            throw EnvelopeIndexError.notAvailable("Fixture open failed: code \(openResult)")
+        }
+
+        let rc = sqlite3_exec(handle, Self.schema + Self.rows + extraSQL, nil, nil, nil)
+        let detail = rc == SQLITE_OK ? "" : String(cString: sqlite3_errmsg(handle))
+        sqlite3_close_v2(handle)
+        guard rc == SQLITE_OK else {
+            throw EnvelopeIndexError.queryFailed("Fixture setup failed: \(detail)")
+        }
+
+        // The accounts store is always addressed inside the throwaway directory, so no test
+        // here can read the developer's real `Accounts4.sqlite`. Without `accountsSQL` the
+        // file is simply never created and `accountNames()` returns an empty map.
+        let accountsPath = tempDir.appendingPathComponent("Accounts4.sqlite")
+        if let accountsSQL {
+            try createDatabase(at: accountsPath, sql: accountsSQL)
+        }
+
+        return try EnvelopeIndex(databasePath: dbPath, accountsDatabasePath: accountsPath)
+    }
+
+    private func createDatabase(at path: URL, sql: String) throws {
+        var handle: OpaquePointer?
+        let openResult = sqlite3_open_v2(
+            path.path, &handle, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil)
+        guard openResult == SQLITE_OK, let handle else {
+            if let handle { sqlite3_close_v2(handle) }
+            throw EnvelopeIndexError.notAvailable("Fixture open failed: code \(openResult)")
+        }
+
+        let result = sqlite3_exec(handle, sql, nil, nil, nil)
+        let detail = result == SQLITE_OK ? "" : String(cString: sqlite3_errmsg(handle))
+        sqlite3_close_v2(handle)
+        guard result == SQLITE_OK else {
+            throw EnvelopeIndexError.queryFailed("Fixture setup failed: \(detail)")
+        }
+    }
+
+    /// Accounts store where ONE username spans TWO logical accounts (`accountUUIDs(matching:)`
+    /// throws `.ambiguous`) — `EnvelopeIndexAccountTests`' SHARED-PARENT pair, children rebound
+    /// to this file's mailbox hosts. Description/username are NULL on the children, carried by
+    /// parents via the production COALESCE join, so `shared@example.com` can only match via the
+    /// username branch.
+    private static let sharedUsernameAccountRows = """
+        CREATE TABLE ZACCOUNT (
+            Z_PK INTEGER PRIMARY KEY,
+            ZIDENTIFIER TEXT,
+            ZACCOUNTDESCRIPTION TEXT,
+            ZUSERNAME TEXT,
+            ZPARENTACCOUNT INTEGER
+        );
+        INSERT INTO ZACCOUNT
+            (Z_PK, ZIDENTIFIER, ZACCOUNTDESCRIPTION, ZUSERNAME, ZPARENTACCOUNT)
+        VALUES
+            (1, 'SHARED-PARENT-A', 'Shared A', 'shared@example.com', NULL),
+            (2, 'GMAIL-ACCOUNT', NULL, NULL, 1),
+            (3, 'SHARED-PARENT-B', 'Shared B', 'shared@example.com', NULL),
+            (4, 'OTHER-ACCOUNT', NULL, NULL, 3);
+        """
+
+    /// A Gmail label membership for message 201, whose PHYSICAL home is `[Gmail]/All Mail`:
+    /// the message is *displayed* in INBOX (mailbox 2) but *stored* under All Mail. This is
+    /// the shape the carried labels fix models, and the only fixture in this file where the
+    /// logical and physical mailbox differ.
+    private static let gmailLabelRows = """
+        CREATE TABLE labels (message_id INTEGER REFERENCES messages(ROWID) ON DELETE CASCADE,
+        mailbox_id INTEGER REFERENCES mailboxes(ROWID) ON DELETE CASCADE,
+        PRIMARY KEY(message_id, mailbox_id)) WITHOUT ROWID;
+        CREATE INDEX labels_mailbox_id_index on labels(mailbox_id);
+
+        INSERT INTO labels (message_id, mailbox_id) VALUES (201, 2);
+
+        """
+
+    /// Mail's own CREATE TABLE statements, copied from a live Envelope Index (the same
+    /// subset `EnvelopeIndexLabelsTests` pins). No `labels` table: the locator resolves by
+    /// message-id, never by mailbox scope, so the Gmail labels arm is not in its path.
+    private static let schema = """
+        CREATE TABLE messages (ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+        message_id INTEGER NOT NULL DEFAULT 0,
+        global_message_id INTEGER NOT NULL,
+        remote_id INTEGER,
+        document_id TEXT COLLATE BINARY,
+        sender INTEGER,
+        subject_prefix TEXT COLLATE BINARY,
+        subject INTEGER NOT NULL,
+        summary INTEGER,
+        date_sent INTEGER,
+        date_received INTEGER,
+        mailbox INTEGER NOT NULL,
+        remote_mailbox INTEGER,
+        flags INTEGER NOT NULL DEFAULT 0,
+        read INTEGER NOT NULL DEFAULT 0,
+        flagged INTEGER NOT NULL DEFAULT 0,
+        deleted INTEGER NOT NULL DEFAULT 0,
+        size INTEGER NOT NULL DEFAULT 0,
+        conversation_id INTEGER NOT NULL DEFAULT 0,
+        date_last_viewed INTEGER,
+        list_id_hash INTEGER,
+        unsubscribe_type INTEGER,
+        searchable_message INTEGER,
+        brand_indicator INTEGER,
+        display_date INTEGER,
+        flag_color INTEGER,
+        is_urgent INTEGER NOT NULL DEFAULT 0,
+        color TEXT COLLATE BINARY,
+        type INTEGER,
+        fuzzy_ancestor INTEGER,
+        automated_conversation INTEGER DEFAULT 0,
+        root_status INTEGER DEFAULT -1);
+
+        CREATE TABLE mailboxes (ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+        url TEXT COLLATE BINARY NOT NULL,
+        total_count INTEGER NOT NULL DEFAULT 0,
+        unread_count INTEGER NOT NULL DEFAULT 0,
+        deleted_count INTEGER NOT NULL DEFAULT 0,
+        unseen_count INTEGER NOT NULL DEFAULT 0,
+        unread_count_adjusted_for_duplicates INTEGER NOT NULL DEFAULT 0,
+        change_identifier TEXT COLLATE BINARY,
+        source INTEGER,
+        alleged_change_identifier TEXT COLLATE BINARY,
+        UNIQUE(url) ON CONFLICT ABORT);
+
+        CREATE TABLE message_global_data (ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+        message_id INTEGER,
+        follow_up_start_date INTEGER,
+        follow_up_end_date INTEGER,
+        follow_up_jsonstringformodelevaluationforsuggestions TEXT COLLATE BINARY,
+        download_state INTEGER NOT NULL DEFAULT 0,
+        read_later_date INTEGER,
+        send_later_date INTEGER,
+        validation_state INTEGER NOT NULL DEFAULT 0,
+        model_category INTEGER,
+        model_subcategory INTEGER,
+        category_model_version INTEGER,
+        category_is_temporary INTEGER,
+        model_analytics TEXT COLLATE BINARY,
+        model_high_impact INTEGER NOT NULL DEFAULT 0,
+        generated_summary INTEGER,
+        urgent INTEGER,
+        message_id_header TEXT COLLATE BINARY,
+        UNIQUE(message_id) ON CONFLICT ABORT);
+
+        CREATE TABLE subjects (ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+        subject TEXT COLLATE RTRIM NOT NULL,
+        UNIQUE(subject) ON CONFLICT ABORT);
+
+        CREATE TABLE addresses (ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+        address TEXT COLLATE NOCASE NOT NULL,
+        comment TEXT COLLATE BINARY NOT NULL,
+        UNIQUE(address, comment) ON CONFLICT ABORT);
+
+        CREATE TABLE attachments (ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+        message INTEGER NOT NULL REFERENCES messages(ROWID) ON DELETE CASCADE,
+        attachment_id TEXT COLLATE BINARY,
+        name TEXT COLLATE BINARY,
+        UNIQUE(message, attachment_id) ON CONFLICT ABORT);
+
+        """
+
+    /// Mailboxes 1/4 nest two deep under Gmail (leaf-vs-path); 5 is a second account's INBOX
+    /// (cross-account selection); 6/7 are top-level and unranked (within-account cases); 3/9/10
+    /// are direct children of the second account (case-folding: `Inbox` unranked exact, rank 0
+    /// folding — EWS's real spelling); 11 is `local://` ("On My Mac") and 13 is `file://`,
+    /// neither of which any JXA account can reach; 12 is an EWS special folder named only after
+    /// percent-decoding. Headers 1-2, 4-23 stored bracketed; header 3 stored bare.
+    private static let rows = """
+        INSERT INTO mailboxes (ROWID, url) VALUES
+        (1, 'imap://GMAIL-ACCOUNT/%5BGmail%5D/All%20Mail'),
+        (2, 'imap://GMAIL-ACCOUNT/INBOX'),
+        (3, 'ews://OTHER-ACCOUNT/Inbox'),
+        (4, 'imap://GMAIL-ACCOUNT/%5BGmail%5D/Trash'),
+        (5, 'ews://OTHER-ACCOUNT/INBOX'),
+        (6, 'imap://GMAIL-ACCOUNT/Receipts'),
+        (7, 'imap://GMAIL-ACCOUNT/Old%20Mail'),
+        (8, 'imap://GMAIL-ACCOUNT/Trash'),
+        (9, 'ews://OTHER-ACCOUNT/Archive'),
+        (10, 'ews://OTHER-ACCOUNT/Receipts'),
+        (11, 'local://LOCAL-ACCOUNT/Saved'),
+        (12, 'ews://OTHER-ACCOUNT/Sent%20Items'),
+        (13, 'file:///Users/example/Library/Mail/V10/Mailboxes/Saved.mbox');
+
+        INSERT INTO addresses (ROWID, address, comment) VALUES
+        (1, 'sender@example.com', 'Example Sender');
+
+        INSERT INTO subjects (ROWID, subject) VALUES (1, 'Fixture subject');
+
+        INSERT INTO message_global_data (ROWID, message_id_header) VALUES
+        (1, '<gmail-only@example.com>'),
+        (2, '<multi@example.com>'),
+        (3, 'bare@example.com'),
+        (4, '<deleted@example.com>'),
+        (5, '<other-acct@example.com>'),
+        (6, '<in-both@example.com>'),
+        (7, '<cross-acct@example.com>'),
+        (8, '<mixed@example.com>'),
+        (9, 'mixed@example.com'),
+        (10, '<mixedsame@example.com>'),
+        (11, 'mixedsame@example.com'),
+        (12, '<hinted@example.com>'),
+        (13, '<nested-outranks@example.com>'),
+        (14, '<two-unranked@example.com>'),
+        (15, '<two-trashes@example.com>'),
+        (16, '<case-variant@example.com>'),
+        (17, '<three-way@example.com>'),
+        (18, '<local-and-server@example.com>'),
+        (19, '<local-only@example.com>'),
+        (20, '<same-mailbox-twice@example.com>'),
+        (21, '<pct-encoded-head@example.com>'),
+        (22, '<file-and-server@example.com>'),
+        (23, '<file-only@example.com>');
+
+        INSERT INTO messages
+        (ROWID, global_message_id, sender, subject, date_received, date_sent, mailbox, read, deleted)
+        VALUES
+        (201, 1, 1, 1, 2000, 2000, 1, 0, 0),
+        (202, 2, 1, 1, 3000, 3000, 4, 0, 0),
+        (203, 2, 1, 1, 1000, 1000, 2, 0, 0),
+        (204, 3, 1, 1, 2000, 2000, 2, 0, 0),
+        (205, 4, 1, 1, 2000, 2000, 2, 0, 1),
+        (206, 5, 1, 1, 2000, 2000, 3, 0, 0),
+        (207, 6, 1, 1, 2000, 2000, 1, 0, 0),
+        (208, 6, 1, 1, 1000, 1000, 2, 0, 0),
+        (209, 7, 1, 1, 3000, 3000, 4, 0, 0),
+        (210, 7, 1, 1, 1000, 1000, 5, 0, 0),
+        (211, 8, 1, 1, 3000, 3000, 4, 0, 0),
+        (212, 9, 1, 1, 1000, 1000, 5, 0, 0),
+        (213, 10, 1, 1, 3000, 3000, 4, 0, 0),
+        (214, 11, 1, 1, 1000, 1000, 2, 0, 0),
+        (215, 12, 1, 1, 1000, 1000, 2, 0, 0),
+        (216, 12, 1, 1, 3000, 3000, 6, 0, 0),
+        (217, 13, 1, 1, 1000, 1000, 4, 0, 0),
+        (218, 13, 1, 1, 3000, 3000, 6, 0, 0),
+        (219, 14, 1, 1, 3000, 3000, 6, 0, 0),
+        (220, 14, 1, 1, 1000, 1000, 7, 0, 0),
+        (221, 15, 1, 1, 1000, 1000, 8, 0, 0),
+        (222, 15, 1, 1, 3000, 3000, 4, 0, 0),
+        (223, 16, 1, 1, 1000, 1000, 9, 0, 0),
+        (224, 16, 1, 1, 2000, 2000, 3, 0, 0),
+        (225, 17, 1, 1, 1000, 1000, 9, 0, 0),
+        (226, 17, 1, 1, 2000, 2000, 10, 0, 0),
+        (227, 17, 1, 1, 3000, 3000, 3, 0, 0),
+        (228, 18, 1, 1, 3000, 3000, 11, 0, 0),
+        (229, 18, 1, 1, 1000, 1000, 2, 0, 0),
+        (230, 19, 1, 1, 2000, 2000, 11, 0, 0),
+        (231, 20, 1, 1, 1000, 1000, 3, 0, 0),
+        (232, 20, 1, 1, 3000, 3000, 3, 0, 0),
+        (233, 21, 1, 1, 1000, 1000, 12, 0, 0),
+        (234, 21, 1, 1, 3000, 3000, 9, 0, 0),
+        (235, 22, 1, 1, 3000, 3000, 13, 0, 0),
+        (236, 22, 1, 1, 1000, 1000, 2, 0, 0),
+        (237, 23, 1, 1, 2000, 2000, 13, 0, 0);
+
+        """
+}

--- a/swift/Tests/MailCLITests/ScriptHelpersTests.swift
+++ b/swift/Tests/MailCLITests/ScriptHelpersTests.swift
@@ -405,9 +405,12 @@ final class ScriptHelpersTests: XCTestCase {
                 + "fromMailbox: mboxName}, _r.lookup));",
         ]
         let notFoundAnchors = [
-            "JSON.stringify(attachLookup({error: \"Message not found: <m@x>\"}, _r.lookup));",
-            "JSON.stringify(attachLookup({error: \"Message not found: <m@x>\"}, _r.lookup));",
-            "JSON.stringify(attachLookup({error: \"Message not found: <m@x>\"}, _r.lookup));",
+            "JSON.stringify(attachLookupWithStats({error: \"Message not found: <m@x>\"}, "
+                + "_r.lookup));",
+            "JSON.stringify(attachLookupWithStats({error: \"Message not found: <m@x>\"}, "
+                + "_r.lookup));",
+            "JSON.stringify(attachLookupWithStats({error: \"Message not found: <m@x>\"}, "
+                + "_r.lookup));",
             "errors.push(attachLookup({id: u.id, error: 'Message not found'}, _r.lookup));",
             "errors.push(attachLookup({id: targetId, error: 'Message not found'}, _r.lookup));",
         ]
@@ -422,9 +425,46 @@ final class ScriptHelpersTests: XCTestCase {
         }
     }
 
+    func testSingleMessageCommandsCarryTheRunCountersInsideTheirLookup() {
+        // A single-message command runs exactly one `findMsg`, so the process counters ARE
+        // that lookup's own tally — `stats` means the same four numbers there as in the batch
+        // summary. Without them a single-op caller can read only `method`, and cannot tell a
+        // byId hit from a scan fallback the way a batch caller can. The counters ride the
+        // SAME debug gate: this helper delegates to `attachLookup`, so nothing new reaches
+        // the un-gated surface.
+        let withStats = "function attachLookupWithStats(obj, lookup) { "
+            + "if (_debug) lookup.stats = _stats; return attachLookup(obj, lookup); }"
+        let scripts = writeScriptsUnderTest()
+
+        for (name, script) in scripts.prefix(3) {
+            let collapsed = Self.collapsingWhitespace(script)
+            XCTAssertTrue(collapsed.contains(withStats),
+                          "\(name): the counter-carrying helper is missing or reshaped")
+            XCTAssertTrue(collapsed.contains("attachLookupWithStats({"),
+                          "\(name): the single-message attach sites must carry the counters")
+            // EVERY attach site, not merely one: a lone `contains` above stays green with the
+            // counters added at the success site and dropped from the error sites. Inside a
+            // single-message script the bare helper is only ever called by the one above,
+            // which passes `obj` — never an object literal.
+            XCTAssertFalse(collapsed.contains("attachLookup({"),
+                           "\(name): an attach site still emits a lookup without the counters")
+        }
+
+        for (name, script) in scripts.suffix(2) {
+            // A batch entry attaches mid-loop, where the counters are a running total rather
+            // than that entry's own; its caller reads the whole-run summary at the end.
+            XCTAssertFalse(script.contains("attachLookupWithStats({"),
+                           "\(name): batch entries must keep the bare per-message lookup")
+            XCTAssertTrue(script.contains("attachLookup({"),
+                          "\(name): the per-entry lookup must still be attached")
+        }
+    }
+
     func testOnlyTheBatchCommandsEmitTheProcessLevelSummary() {
         // The shared helper defines `getLookupSummary()` in all five scripts; only the two
-        // batch commands call it. Asserted so the absence stays a choice.
+        // batch commands call it, and only they put the counters on the UN-gated surface. The
+        // single-message commands carry the same counters behind `MAIL_CLI_DEBUG=1`, inside
+        // their `_lookup` (above). Asserted so the absence stays a choice.
         let scripts = writeScriptsUnderTest()
         for (name, script) in scripts.prefix(3) {
             XCTAssertFalse(script.contains("output._lookup = getLookupSummary();"),
@@ -439,7 +479,8 @@ final class ScriptHelpersTests: XCTestCase {
     func testPerMessageLookupDetailIsEmittedOnlyBehindTheDebugGate() {
         // The per-message lookup names an internal account UUID and an Envelope-Index ROWID,
         // and repeats on every entry of a batch, so it belongs on the debug surface. One
-        // shared helper carries the gate, which is what makes its absence elsewhere provable:
+        // shared helper is the only writer of `_lookup` — `attachLookupWithStats` delegates to
+        // it rather than assigning its own — which is what makes the gate's presence provable:
         // strike the gated helper and the process summary — a different contract, four
         // counters and a label — and no `_lookup` may remain anywhere in any of the five.
         let gatedHelper = "function attachLookup(obj, lookup) { if (_debug) obj._lookup = lookup;"

--- a/swift/Tests/MailCLITests/ScriptHelpersTests.swift
+++ b/swift/Tests/MailCLITests/ScriptHelpersTests.swift
@@ -188,31 +188,32 @@ final class ScriptHelpersTests: XCTestCase {
         XCTAssertEqual(emitted, mailboxPriority)
     }
 
-    func testTheThreeMailboxPriorityCopiesHaveNotDrifted() {
-        // `findMessageJXA` keeps five live callers and `batchFindMessageJXA` is retained for
-        // its own test, so their inline literals stay. This is what stops the new emitter
-        // becoming a third, divergent copy.
+    func testTheLegacyFindersMailboxPriorityCopyHasNotDrifted() {
+        // `findMessageJXA` keeps five live callers, so its inline literal stays. Together with
+        // the emitted list above — pinned against the same Swift constant — this is what stops
+        // the two shipped finders sweeping different mailboxes in a different order.
+        //
+        // `batchFindMessageJXA` carries a third copy of the literal and is deliberately NOT
+        // asserted here: nothing calls it, so drift in it ships nothing. See its own NOTE.
         let legacySingle = Self.jsStringArray(
             in: findMessageJXA(targetId: "<id>", mailbox: nil, account: nil),
             after: "const priority = [")
-        let legacyBatch = Self.jsStringArray(
-            in: batchFindMessageJXA(mailbox: nil, account: nil), after: "const priority = [")
 
         XCTAssertEqual(legacySingle, mailboxPriority)
-        XCTAssertEqual(legacyBatch, mailboxPriority)
     }
 
-    func testAllThreeFindersSweepAccountOuterNotPriorityOuter() {
+    func testBothShippedFindersSweepAccountOuterNotPriorityOuter() {
         // Traversal ORDER, which the array comparison above cannot see and which decides
         // WHICH PHYSICAL COPY a delete or a move acts on when the same Message-ID exists in
         // two accounts. Account-outer exhausts one account's whole priority list before
         // looking at the next, so a copy in A/Trash wins over a copy in B/INBOX.
         // Priority-outer inverts that and silently retargets the write at another account.
+        //
+        // The two finders with callers: the read/reply/attachment scan, and the write path's
+        // emitter. `batchFindMessageJXA` sweeps the same way and is not asserted — no caller,
+        // so its order decides nothing.
         let cases: [(String, String, String)] = [
             (findMessageJXA(targetId: "<id>", mailbox: nil, account: nil),
-             "for (let a = 0; a < accounts.length; a++) {",
-             "for (let p = 0; p < priority.length; p++) {"),
-            (batchFindMessageJXA(mailbox: nil, account: nil),
              "for (let a = 0; a < accounts.length; a++) {",
              "for (let p = 0; p < priority.length; p++) {"),
             (unifiedScript(),

--- a/swift/Tests/MailCLITests/ScriptHelpersTests.swift
+++ b/swift/Tests/MailCLITests/ScriptHelpersTests.swift
@@ -32,6 +32,504 @@ final class ScriptHelpersTests: XCTestCase {
         XCTAssertTrue(script.contains("function findMsg(targetId)"))
     }
 
+    // MARK: - Unified finder (SQLite rowid fast path + JXA fallback)
+    //
+    // Nothing here executes the generated JXA: running `osascript` against Mail.app is off
+    // limits in the build environment. These are string-shape assertions only. What they can
+    // pin is that the emitted script asks for the right things; what they cannot pin is that
+    // Mail.app answers — that is what the `_stats` telemetry on a real batch is for.
+
+    private func unifiedScript(rowidMapJS: String = "{}", backend: String = "sqlite",
+                               mailbox: String? = nil, account: String? = nil) -> String {
+        generateUnifiedFindMsgJXA(
+            rowidMapJS: rowidMapJS, backend: backend, mailbox: mailbox, account: account)
+    }
+
+    func testUnifiedFinderEmitsTheRowidMapAndHintsItWasGiven() {
+        let script = unifiedScript(rowidMapJS: "{\"a@b\":[{\"r\":7}]}",
+                                   mailbox: "Inbox 'Primary'", account: "Personal \"Account\"")
+        XCTAssertTrue(script.contains("const rowidMap = {\"a@b\":[{\"r\":7}]};"))
+        XCTAssertTrue(script.contains("const mboxHint = 'Inbox \\'Primary\\'';"))
+        XCTAssertTrue(script.contains("const acctHint = 'Personal \\\"Account\\\"';"))
+    }
+
+    func testUnifiedFinderEmitsNullHintsWhenNotProvided() {
+        let script = unifiedScript()
+        XCTAssertTrue(script.contains("const rowidMap = {};"))
+        XCTAssertTrue(script.contains("const mboxHint = null;"))
+        XCTAssertTrue(script.contains("const acctHint = null;"))
+        XCTAssertTrue(script.contains("function findMsg(targetId)"))
+    }
+
+    func testUnifiedFinderVerifiesTheMessageIdBeforeAcceptingAByIdHit() {
+        // Layer 1, and the only thing that makes a stale Envelope-Index ROWID safe: a wrong
+        // rowid can never be returned, only fallen through. It is also load-bearing ALONE on
+        // the update paths, which carry no pre-op re-read.
+        //
+        // Asserted as ONE contiguous span, not as two substrings. The compare and the counter
+        // can both be present while the accept has been hoisted out of the guarded block —
+        // every `byId` result taken unverified, the guard decorative, and a pair of
+        // `contains` checks still green. Spanning from the compare through the closing brace
+        // and on to the mismatch counter is what forbids that: nothing may sit between the
+        // compare and the accept, and the return may not leave the block.
+        XCTAssertTrue(
+            Self.collapsingWhitespace(unifiedScript()).contains(
+                "if (normalizeMessageId(msg.messageId()) === normalized) { "
+                + "_stats.byIdHits++; "
+                + "lookup.method = 'byId'; "
+                + "lookup.acctId = cand.acctId || ''; "
+                + "lookup.mb = cand.mb || ''; "
+                + "lookup.rowid = cand.r; "
+                + "if (_debug) { "
+                + "lookup._diag = {acctResolved: acct.name(), mbHandle: mb.name()}; "
+                + "lookup._perfMs = Date.now() - _t0; "
+                + "} "
+                + "return {msg: msg, lookup: lookup}; "
+                + "} "
+                + "_stats.byIdMismatches++;"),
+            "the byId result must be returned only from inside the messageId compare, with a "
+            + "mismatch counted on the way out")
+    }
+
+    func testUnifiedFinderDeclaresAllFourTelemetryCounters() {
+        // byIdHits vs byIdMismatches vs jxaFallbacks is the only instrument that can tell
+        // "fast path working" from "silently falling back to the same slow scan".
+        let script = unifiedScript()
+        for counter in ["byIdHits", "byIdMismatches", "jxaFallbacks", "notFound"] {
+            XCTAssertTrue(script.contains(counter), "missing counter \(counter)")
+        }
+        XCTAssertTrue(script.contains("function getLookupSummary()"))
+    }
+
+    func testUnifiedFinderReportsTheBackendSwiftActuallyBuilt() {
+        // Derived in JS from "did any rowidMap entry have candidates", the label cannot tell
+        // "no Full Disk Access" from "SQLite ran and matched nothing" — exactly the
+        // distinction the acceptance gate needs. Swift knows, so Swift emits it.
+        XCTAssertTrue(unifiedScript(backend: "sqlite").contains("const _locatorBackend = 'sqlite';"))
+        XCTAssertTrue(unifiedScript(backend: "jxa-only").contains("const _locatorBackend = 'jxa-only';"))
+    }
+
+    func testUnifiedFinderAddressesTheRowidThroughAnyMailboxOfTheAccount() {
+        // `messages.byId` is keyed to the Envelope-Index ROWID and resolves GLOBALLY, so the
+        // arm needs A mailbox handle, not the RIGHT one: resolve the account, take any of its
+        // mailboxes, address the rowid, and let Layer 1 below decide. Asserted as one span so
+        // the handle guard cannot be separated from the call it protects, and so the byId
+        // result still flows straight into the messageId compare.
+        XCTAssertTrue(
+            Self.collapsingWhitespace(unifiedScript()).contains(
+                "var acct = null; "
+                + "if (cand.acctId) acct = getAccountById(cand.acctId); "
+                + "if (!acct && cand.acct) acct = getAccountByName(cand.acct); "
+                + "if (!acct) continue; "
+                + "var mb = anyMailboxOf(acct); "
+                + "if (!mb) continue; "
+                + "try { "
+                + "var msg = mb.messages.byId(cand.r);"),
+            "the byId arm must resolve the account, take any mailbox handle of it, and address "
+            + "the rowid through that handle")
+    }
+
+    func testTheFastPathsMailLookupsDegradeToTheScanInsteadOfThrowing() {
+        // Every Mail call on the byId arm answers null on failure so the write falls through
+        // to the `whose` scan — correct but slow, never wrong. An unguarded call breaks that:
+        // the exception leaves `findMsg` and fails a write the scan could have completed.
+        // Spanning from the `try` through the call proves the call is inside it.
+        let collapsed = Self.collapsingWhitespace(unifiedScript())
+        XCTAssertTrue(collapsed.contains(
+            "var matches = []; try { matches = Mail.accounts.whose({name: name})(); } "
+            + "catch(e) { return null; }"),
+            "the by-name account lookup must degrade to null, not throw")
+        XCTAssertTrue(collapsed.contains("try { accts = Mail.accounts(); } catch(e) {}"),
+                      "the by-id account enumeration must stay guarded too")
+        XCTAssertTrue(collapsed.contains(
+            "var mbs = []; try { mbs = acct.mailboxes(); } catch(e) { return null; } "
+            + "return mbs.length > 0 ? mbs[0] : null;"),
+            "the mailbox-handle lookup must degrade to null, not throw")
+    }
+
+    func testUnifiedFinderKeepsTheExistingWhoseScanAsItsFallback() {
+        let script = unifiedScript()
+        XCTAssertTrue(script.contains("mbox.messages.whose({messageId: targetId})"))
+        XCTAssertTrue(script.contains("_stats.jxaFallbacks++"))
+        // Visited-mailbox bookkeeping is a Set, as in `batchFindMessageJXA`: a plain object
+        // keyed by account/mailbox names is a prototype lookup wearing a map's clothes, the
+        // same hazard the rowid map is read with `hasOwnProperty.call` to avoid.
+        XCTAssertTrue(script.contains("var searched = new Set();"))
+        XCTAssertFalse(script.contains("searched["))
+    }
+
+    func testUnifiedFinderPriorityListMatchesTheSwiftConstant() {
+        let emitted = Self.jsStringArray(in: unifiedScript(), after: "const MAILBOX_PRIORITY = [")
+        XCTAssertEqual(emitted, mailboxPriority)
+    }
+
+    func testTheThreeMailboxPriorityCopiesHaveNotDrifted() {
+        // `findMessageJXA` keeps five live callers and `batchFindMessageJXA` is retained for
+        // its own test, so their inline literals stay. This is what stops the new emitter
+        // becoming a third, divergent copy.
+        let legacySingle = Self.jsStringArray(
+            in: findMessageJXA(targetId: "<id>", mailbox: nil, account: nil),
+            after: "const priority = [")
+        let legacyBatch = Self.jsStringArray(
+            in: batchFindMessageJXA(mailbox: nil, account: nil), after: "const priority = [")
+
+        XCTAssertEqual(legacySingle, mailboxPriority)
+        XCTAssertEqual(legacyBatch, mailboxPriority)
+    }
+
+    func testAllThreeFindersSweepAccountOuterNotPriorityOuter() {
+        // Traversal ORDER, which the array comparison above cannot see and which decides
+        // WHICH PHYSICAL COPY a delete or a move acts on when the same Message-ID exists in
+        // two accounts. Account-outer exhausts one account's whole priority list before
+        // looking at the next, so a copy in A/Trash wins over a copy in B/INBOX.
+        // Priority-outer inverts that and silently retargets the write at another account.
+        let cases: [(String, String, String)] = [
+            (findMessageJXA(targetId: "<id>", mailbox: nil, account: nil),
+             "for (let a = 0; a < accounts.length; a++) {",
+             "for (let p = 0; p < priority.length; p++) {"),
+            (batchFindMessageJXA(mailbox: nil, account: nil),
+             "for (let a = 0; a < accounts.length; a++) {",
+             "for (let p = 0; p < priority.length; p++) {"),
+            (unifiedScript(),
+             "for (var a = 0; a < accounts.length; a++) {",
+             "for (var p = 0; p < MAILBOX_PRIORITY.length; p++) {"),
+        ]
+        for (script, accountLoop, priorityLoop) in cases {
+            guard let between = Self.textBetweenNearestEnclosingLoop(
+                in: script, outer: accountLoop, inner: priorityLoop) else {
+                return XCTFail("finder must sweep accounts and the priority list")
+            }
+            XCTAssertTrue(between.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                          "the priority loop must sit DIRECTLY inside the account loop; found "
+                          + "\(between.debugDescription) between them")
+        }
+    }
+
+    /// Text between the nearest preceding `outer` loop header and the `inner` loop header.
+    /// Whitespace-only means `inner` is `outer`'s immediate body, i.e. `outer` is the outer
+    /// loop. Anything else means some other block closed in between.
+    private static func textBetweenNearestEnclosingLoop(
+        in script: String, outer: String, inner: String) -> String? {
+        guard let innerRange = script.range(of: inner) else { return nil }
+        let head = script[script.startIndex..<innerRange.lowerBound]
+        guard let outerRange = head.range(of: outer, options: .backwards) else { return nil }
+        return String(script[outerRange.upperBound..<innerRange.lowerBound])
+    }
+
+    func testUnifiedFinderNeverLooksACandidateMailboxUpByName() {
+        // Neither a path walk nor a leaf-name `whose` arm. Both were ways to find the mailbox
+        // that HOLDS the message, which `byId` does not need, and both rest on the Envelope
+        // Index's mailbox name (the SERVER's folder name) matching JXA's `mb.name()` (what Mail
+        // displays, renamed for Gmail's special mailboxes) — an assumption that bought nothing
+        // and cost the whole Gmail fast path when it failed.
+        let script = unifiedScript()
+        XCTAssertFalse(script.contains("cand.path"))
+        XCTAssertFalse(script.contains("findMailboxByPath"))
+        XCTAssertFalse(script.contains("[cand.mb]"))
+        XCTAssertFalse(script.contains("whose({name: cand"))
+    }
+
+    func testUnifiedFinderSkipsTheFastPathForAnEmptyMessageId() {
+        // An empty id normalizes to '' and so does a message whose messageId() is null, so
+        // Layer 1's compare would pass on any rowid carrying an empty header. The `whose`
+        // scan could never address such a message; the rowid path can, so it is gated off.
+        let script = unifiedScript()
+        XCTAssertTrue(script.contains("var _own = normalized && "))
+        XCTAssertTrue(script.contains("var candidates = _own ? rowidMap[normalized] : [];"))
+    }
+
+    func testUnifiedFinderReadsTheRowidMapWithAnOwnPropertyCheck() {
+        // A bare `rowidMap[normalized]` resolves an id that normalizes to an Object.prototype
+        // member ('constructor', 'hasOwnProperty', 'isPrototypeOf', 'propertyIsEnumerable') to
+        // the INHERITED function. Those four have `.length >= 1`, so the candidate loop runs
+        // once with `candidates[0] === undefined` and throws a TypeError out of the write —
+        // never a wrong copy, but a crafted Message-ID should not be able to fail a command.
+        let script = unifiedScript()
+        XCTAssertTrue(script.contains("Object.prototype.hasOwnProperty.call(rowidMap, normalized)"))
+        XCTAssertFalse(script.contains("rowidMap[normalized] || []"))
+    }
+
+    func testMailboxPriorityJSONParsesBackToTheSwiftConstant() {
+        let data = mailboxPriorityJSON().data(using: .utf8)
+        XCTAssertEqual(data.flatMap { try? JSONSerialization.jsonObject(with: $0) } as? [String],
+                       mailboxPriority)
+    }
+
+    func testPriorityRankPrefersInboxAndSortsUnknownMailboxesLast() {
+        XCTAssertEqual(priorityRank(forMailboxName: "INBOX"), 0)
+        XCTAssertLessThan(priorityRank(forMailboxName: "All Mail"),
+                          priorityRank(forMailboxName: "Trash"))
+        XCTAssertEqual(priorityRank(forMailboxName: "Some Custom Folder"), mailboxPriority.count)
+        // The leaf, not the joined path: this is the ranking half of the Gmail defect.
+        XCTAssertLessThan(priorityRank(forMailboxName: "All Mail"),
+                          priorityRank(forMailboxName: "[Gmail]/All Mail"))
+    }
+
+    func testTheTwoPriorityRanksDisagreeExactlyOnACaseVariant() {
+        // The write-path guard certifies a head only if it wins under BOTH readings of
+        // `mailboxes.whose({name: …})`, so the two ranks must be genuinely different functions.
+        // `Inbox` is the case that matters: unranked to the exact compare, rank 0 to the
+        // folding one — over-ranking a non-head candidate is the dangerous direction, because
+        // the head then looks certified when the scan would reach the other copy first.
+        XCTAssertEqual(priorityRank(forMailboxName: "Inbox"), mailboxPriority.count)
+        XCTAssertEqual(priorityRankFoldingCase(forMailboxName: "Inbox"), 0)
+
+        // Agreement everywhere else: an exact entry, and a name in neither list.
+        XCTAssertEqual(priorityRankFoldingCase(forMailboxName: "INBOX"), 0)
+        XCTAssertEqual(priorityRankFoldingCase(forMailboxName: "Some Custom Folder"),
+                       mailboxPriority.count)
+        // Folding is case only — a hyphen difference is still a different mailbox name.
+        XCTAssertEqual(priorityRankFoldingCase(forMailboxName: "Junk E-Mail"),
+                       mailboxPriority.firstIndex(of: "Junk E-mail"))
+    }
+
+    // MARK: - messageId drift guard (Layer 2), and its deliberate asymmetry
+
+    func testDestructiveCommandScriptsRefuseToActOnADriftedMessageId() {
+        // Two spans per command, because there are two ways to keep the drift guard's text
+        // while removing the guard. The COMPARE span carries its operands, so a guard reduced
+        // to a constant condition — the drift message still sitting in a dead arm — fails it.
+        // The ACT span runs from the guarded arm's brace through the destructive call, so a
+        // call hoisted out of that arm fails it. Substring checks for the drift message and
+        // for `preOpId` survive both, which is what makes them insufficient here.
+        let finder = unifiedScript()
+        let move = MoveMessage.buildScript(
+            id: "<m@x>", toMailbox: "Archive", toAccount: nil, findHelper: finder)
+        let delete = DeleteMessage.buildScript(id: "<m@x>", findHelper: finder)
+        let batchDelete = BatchDeleteMessages.buildScript(jsIds: "'<m@x>'", findHelper: finder)
+
+        let cases: [(name: String, script: String, compare: String, act: String)] = [
+            ("move", move,
+             "var preOpId = normalizeMessageId(msg.messageId()); "
+                + "if (preOpId !== normalizeMessageId('<m@x>')) {",
+             "} else { const fromMailbox = msg.mailbox().name(); "
+                + "Mail.move(msg, {to: destMbox});"),
+            ("delete", delete,
+             "var preOpId = normalizeMessageId(msg.messageId()); "
+                + "if (preOpId !== normalizeMessageId('<m@x>')) {",
+             "} else { const subject = msg.subject(); const mboxName = msg.mailbox().name(); "
+                + "Mail.delete(msg);"),
+            ("batch-delete", batchDelete,
+             "var preOpId = normalizeMessageId(msg.messageId()); "
+                + "if (preOpId !== normalizeMessageId(targetId)) {",
+             "continue; } const subject = msg.subject(); "
+                + "const mboxName = msg.mailbox().name(); Mail.delete(msg);"),
+        ]
+
+        for (name, script, compare, act) in cases {
+            let collapsed = Self.collapsingWhitespace(script)
+            XCTAssertTrue(collapsed.contains(compare),
+                          "\(name): the pre-op re-read must be compared against the requested id")
+            XCTAssertTrue(collapsed.contains(act),
+                          "\(name): the destructive call must sit inside the arm the compare guards")
+        }
+
+        XCTAssertTrue(move.contains("messageId drift detected before move"))
+        XCTAssertTrue(delete.contains("messageId drift detected before delete"))
+        XCTAssertTrue(batchDelete.contains("messageId drift detected before delete"))
+        // The batch keeps going after a drifted id rather than abandoning the rest.
+        XCTAssertTrue(batchDelete.contains("errors.push"))
+        XCTAssertTrue(batchDelete.contains("continue;"))
+    }
+
+    func testFlagUpdateScriptsCarryNoPreOpReReadByDesign() {
+        // Asserted as deliberately as the presence above. A flag flip is reversible and a
+        // delete is not, so the old branch guarded only the destructive ops — which leaves
+        // the post-byId messageId verify (Layer 1) load-bearing alone on precisely the
+        // flag-write path this port exists to accelerate. Pinned so it stays a choice.
+        let finder = unifiedScript()
+        let update = UpdateMessage.buildScript(
+            id: "<m@x>", updateCode: "msg.readStatus = true;", findHelper: finder)
+        let batchUpdate = BatchUpdateMessages.buildScript(
+            jsUpdates: "{id: '<m@x>', read: true}", findHelper: finder)
+
+        for script in [update, batchUpdate] {
+            XCTAssertFalse(script.contains("preOpId"))
+            XCTAssertFalse(script.contains("messageId drift detected"))
+        }
+    }
+
+    /// The five write scripts, built from one finder so a test can vary the debug mode.
+    private func writeScriptsUnderTest(debug: Bool = false)
+        -> [(name: String, script: String)] {
+        let finder = generateUnifiedFindMsgJXA(
+            rowidMapJS: "{}", backend: "sqlite", mailbox: nil, account: nil, debug: debug)
+        return [
+            ("update", UpdateMessage.buildScript(
+                id: "<m@x>", updateCode: "", findHelper: finder)),
+            ("move", MoveMessage.buildScript(
+                id: "<m@x>", toMailbox: "Archive", toAccount: nil, findHelper: finder)),
+            ("delete", DeleteMessage.buildScript(id: "<m@x>", findHelper: finder)),
+            ("batch-update", BatchUpdateMessages.buildScript(
+                jsUpdates: "", findHelper: finder)),
+            ("batch-delete", BatchDeleteMessages.buildScript(jsIds: "", findHelper: finder)),
+        ]
+    }
+
+    func testEveryWriteCommandScriptAttachesLookupTelemetryToBothItsResultAndItsErrorPath() {
+        // Two anchors per script, not one `contains`. Every one of these attaches the lookup
+        // at a success site AND at a not-found site, so a lone substring match would stay
+        // green with the success attachment deleted from all five — the site a consumer reads
+        // on the happy path, and the one the test's name claims to cover.
+        let successAnchors = [
+            "isJunk: msg.junkMailStatus() }, _r.lookup));",
+            "moved: true }, _r.lookup));",
+            "deleted: true }, _r.lookup));",
+            "isJunk: msg.junkMailStatus() }, _r.lookup));",
+            "results.push(attachLookup({id: targetId, subject: subject, "
+                + "fromMailbox: mboxName}, _r.lookup));",
+        ]
+        let notFoundAnchors = [
+            "JSON.stringify(attachLookup({error: \"Message not found: <m@x>\"}, _r.lookup));",
+            "JSON.stringify(attachLookup({error: \"Message not found: <m@x>\"}, _r.lookup));",
+            "JSON.stringify(attachLookup({error: \"Message not found: <m@x>\"}, _r.lookup));",
+            "errors.push(attachLookup({id: u.id, error: 'Message not found'}, _r.lookup));",
+            "errors.push(attachLookup({id: targetId, error: 'Message not found'}, _r.lookup));",
+        ]
+
+        for (index, (name, script)) in writeScriptsUnderTest().enumerated() {
+            let collapsed = Self.collapsingWhitespace(script)
+            XCTAssertTrue(collapsed.contains(successAnchors[index]),
+                          "\(name): the result path must carry the lookup")
+            XCTAssertTrue(collapsed.contains(notFoundAnchors[index]),
+                          "\(name): the not-found error path must carry the lookup")
+            XCTAssertTrue(script.contains("const _r = findMsg("))
+        }
+    }
+
+    func testOnlyTheBatchCommandsEmitTheProcessLevelSummary() {
+        // The shared helper defines `getLookupSummary()` in all five scripts; only the two
+        // batch commands call it. Asserted so the absence stays a choice.
+        let scripts = writeScriptsUnderTest()
+        for (name, script) in scripts.prefix(3) {
+            XCTAssertFalse(script.contains("output._lookup = getLookupSummary();"),
+                           "\(name): single-message commands emit no aggregate")
+        }
+        for (name, script) in scripts.suffix(2) {
+            XCTAssertTrue(script.contains("output._lookup = getLookupSummary();"),
+                          "\(name): the aggregate must be emitted")
+        }
+    }
+
+    func testPerMessageLookupDetailIsEmittedOnlyBehindTheDebugGate() {
+        // The per-message lookup names an internal account UUID and an Envelope-Index ROWID,
+        // and repeats on every entry of a batch, so it belongs on the debug surface. One
+        // shared helper carries the gate, which is what makes its absence elsewhere provable:
+        // strike the gated helper and the process summary — a different contract, four
+        // counters and a label — and no `_lookup` may remain anywhere in any of the five.
+        let gatedHelper = "function attachLookup(obj, lookup) { if (_debug) obj._lookup = lookup;"
+            + " return obj; }"
+        for (name, script) in writeScriptsUnderTest() {
+            let collapsed = Self.collapsingWhitespace(script)
+            XCTAssertTrue(collapsed.contains(gatedHelper),
+                          "\(name): the per-message lookup helper is missing or reshaped")
+
+            var stripped = collapsed.replacingOccurrences(of: gatedHelper, with: "")
+            stripped = stripped.replacingOccurrences(
+                of: "output._lookup = getLookupSummary();", with: "")
+            XCTAssertFalse(stripped.contains("_lookup"),
+                           "\(name): an un-gated per-message _lookup remains")
+        }
+    }
+
+    // MARK: - The aggregate locator summary reaches production stdout
+    //
+    // The one thing on the normal output surface that can tell the SQLite fast path from the
+    // scan it falls back to. `byIdMismatches` especially is unreachable any other way (a
+    // mismatch's row reads `method: 'whose'`, indistinguishable from a plain miss). Four
+    // counters + backend label, no identifiers, no Apple Events, so always emitted; everything
+    // per-message stays gated — `_diag`/`_perfMs` spend Apple Events, and the per-message
+    // lookup names an account UUID on every row of a batch.
+
+    private func batchScriptsUnderTest(debug: Bool = false) -> [(name: String, script: String)] {
+        Array(writeScriptsUnderTest(debug: debug).suffix(2))
+    }
+
+    func testBothBatchScriptsEmitTheLocatorSummaryUnconditionally() {
+        // Asserted under BOTH debug modes: the summary's whole value is that a production
+        // caller with no MAIL_CLI_DEBUG in its environment still gets it, and only building
+        // the script both ways can show the gate is absent rather than merely satisfied.
+        for debug in [false, true] {
+            for (name, script) in batchScriptsUnderTest(debug: debug) {
+                let label = "\(name) (debug=\(debug))"
+                XCTAssertTrue(script.contains("const _debug = \(debug);"),
+                              "\(label): the finder must carry the debug mode it was given")
+                XCTAssertFalse(script.contains("if (_debug) output._lookup"),
+                               "\(label): the aggregate summary must not be debug-gated")
+                // Spanning the declaration through the serialize proves nothing sits between
+                // them — no gate, no early return — not merely that the assignment appears.
+                XCTAssertTrue(
+                    Self.collapsingWhitespace(script).contains(
+                        "var output = {results: results, errors: errors}; "
+                        + "output._lookup = getLookupSummary(); JSON.stringify(output);"),
+                    "\(label): the summary must be assigned unconditionally between the output "
+                    + "declaration and JSON.stringify")
+                // The payload the summary carries, which is the half a consumer parses.
+                XCTAssertTrue(
+                    Self.collapsingWhitespace(script).contains(
+                        "function getLookupSummary() { return {backend: _locatorBackend, "
+                        + "stats: _stats}; }"),
+                    "\(label): the summary shape must stay backend + stats")
+                XCTAssertTrue(
+                    script.contains("var _stats = {byIdHits: 0, byIdMismatches: 0, "
+                                    + "jxaFallbacks: 0, notFound: 0};"),
+                    "\(label): the four counters must stay declared, whatever the debug mode")
+            }
+        }
+    }
+
+    func testBothBatchScriptsKeepPerMessageDebugDiagnosticsGated() {
+        let gatedBlock = "if (_debug) { lookup._diag = {acctResolved: acct.name(), "
+            + "mbHandle: mb.name()}; lookup._perfMs = Date.now() - _t0; }"
+        let gatedInline = "if (_debug) lookup._perfMs = Date.now() - _t0;"
+
+        for (name, script) in batchScriptsUnderTest() {
+            let collapsed = Self.collapsingWhitespace(script)
+            // Presence first: without these, a reshaped literal would surface below as a
+            // phantom "un-gated _diag" rather than as the mismatch it actually is.
+            XCTAssertTrue(collapsed.contains(gatedBlock),
+                          "\(name): the byId diagnostics block is missing or reshaped")
+            XCTAssertTrue(collapsed.contains(gatedInline),
+                          "\(name): the fallback _perfMs gate is missing or reshaped")
+            XCTAssertTrue(collapsed.contains("var _t0 = _debug ? Date.now() : 0;"),
+                          "\(name): the _t0 clock must stay debug-gated")
+
+            var stripped = collapsed.replacingOccurrences(of: gatedBlock, with: "")
+            stripped = stripped.replacingOccurrences(of: gatedInline, with: "")
+            XCTAssertFalse(stripped.contains("_perfMs"), "\(name): an un-gated _perfMs remains")
+            XCTAssertFalse(stripped.contains("_diag"), "\(name): an un-gated _diag remains")
+        }
+    }
+
+    /// Whitespace-collapsed copy of a script, so a needle may span emitted lines without
+    /// pinning the indentation the string interpolation happens to produce.
+    private static func collapsingWhitespace(_ script: String) -> String {
+        script.split(whereSeparator: { $0 == " " || $0 == "\n" || $0 == "\t" })
+            .joined(separator: " ")
+    }
+
+    func testWriteCommandScriptsDeclareMailBeforeTheFinderHelper() {
+        // The emitted helper closes over `Mail`; the caller must declare it first.
+        let finder = unifiedScript()
+        let script = UpdateMessage.buildScript(id: "<m@x>", updateCode: "", findHelper: finder)
+        guard let mailDecl = script.range(of: "const Mail = Application(\"Mail\");"),
+              let helperUse = script.range(of: "function findMsg(targetId)") else {
+            return XCTFail("script must declare Mail and embed the finder helper")
+        }
+        XCTAssertLessThan(mailDecl.lowerBound, helperUse.lowerBound)
+    }
+
+    /// Pull a JS array of single- or double-quoted strings out of an emitted script.
+    private static func jsStringArray(in script: String, after marker: String) -> [String]? {
+        guard let start = script.range(of: marker) else { return nil }
+        let rest = script[start.upperBound...]
+        guard let end = rest.range(of: "]") else { return nil }
+        return rest[..<end.lowerBound]
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: " \n\t'\"")) }
+            .filter { !$0.isEmpty }
+    }
+
     // MARK: - Reply script (issue #67)
 
     func testReplyScriptDoesNotUseBrittleByNameMailboxSpecifier() {

--- a/swift/Tests/MailCLITests/ScriptHelpersTests.swift
+++ b/swift/Tests/MailCLITests/ScriptHelpersTests.swift
@@ -71,10 +71,12 @@ final class ScriptHelpersTests: XCTestCase {
         // every `byId` result taken unverified, the guard decorative, and a pair of
         // `contains` checks still green. Spanning from the compare through the closing brace
         // and on to the mismatch counter is what forbids that: nothing may sit between the
-        // compare and the accept, and the return may not leave the block.
+        // compare and the accept, and the return may not leave the block. The span also fixes
+        // the re-anchor's position; the test below is where that line is explained.
         XCTAssertTrue(
             Self.collapsingWhitespace(unifiedScript()).contains(
                 "if (normalizeMessageId(msg.messageId()) === normalized) { "
+                + "msg = msg.mailbox().messages.byId(cand.r); "
                 + "_stats.byIdHits++; "
                 + "lookup.method = 'byId'; "
                 + "lookup.acctId = cand.acctId || ''; "
@@ -127,6 +129,29 @@ final class ScriptHelpersTests: XCTestCase {
                 + "var msg = mb.messages.byId(cand.r);"),
             "the byId arm must resolve the account, take any mailbox handle of it, and address "
             + "the rowid through that handle")
+    }
+
+    func testUnifiedFinderReAnchorsTheAcceptedSpecifierThroughTheMessagesOwnMailbox() {
+        // The handle that FINDS a message is not enough to ACT on it. `messages.byId` resolves
+        // a ROWID globally for property access — reads and writes alike — but the `delete` and
+        // `move` commands re-resolve the specifier's container chain and refuse with "Can't get
+        // object." when the mailbox it was addressed through does not hold the message. Flag
+        // writes are property access, so they never saw it; every delete and move the fast path
+        // located failed. The accepted specifier is therefore re-addressed through the
+        // message's OWN mailbox before it leaves the finder.
+        //
+        // One span, and the ORDER inside it is the assertion: the re-anchor must sit between
+        // the accept and `byIdHits++`. There, a re-anchor that throws leaves the counter
+        // untouched and falls out of the guarded block to the scan, which counts its own
+        // fallback. Below the counter, the same throw would leave a phantom hit behind and one
+        // message would report as both a hit and a fallback.
+        XCTAssertTrue(
+            Self.collapsingWhitespace(unifiedScript()).contains(
+                "if (normalizeMessageId(msg.messageId()) === normalized) { "
+                + "msg = msg.mailbox().messages.byId(cand.r); "
+                + "_stats.byIdHits++;"),
+            "the accepted specifier must be re-anchored through its own mailbox, before the hit "
+            + "is counted")
     }
 
     func testTheFastPathsMailLookupsDegradeToTheScanInsteadOfThrowing() {


### PR DESCRIPTION
## What problem are we attempting to solve?

`update`, `move`, `delete`, `batch-update` and `batch-delete` find their target by asking Mail.app
to scan mailbox after mailbox with a `whose()` predicate until a Message-ID matches. On a large
account that costs seconds per message, and a ten-message batch runs close to the 30-second cap —
slow enough to time out on exactly the workload the batch commands exist for.

## The fix

Look the message up in Mail's Envelope Index first — Message-ID header to `messages.ROWID` through
the existing read-only SQLite path — and hand JXA the row-id via `mailbox.messages.byId(rowid)`.
The mailbox-by-mailbox scan is untouched and stays as the fallback for anything the lookup declines
or misses; its account-outer sweep order is preserved byte for byte. Nothing here writes to Mail's
database: the index is opened read-only, and the write itself still goes through Mail.app.

The lookup never decides a write on its own. Every row-id hit is accepted only after the message's
own Message-ID matches the one requested, on all five commands; once accepted, the specifier is
re-anchored through the message's own mailbox, so a handle that cannot contain the message falls
through to the scan rather than failing the operation. `move`, `delete` and `batch-delete`
additionally re-read the message immediately before acting and refuse if it drifted; the flag writes
deliberately do not, because a flag flip can be flipped back and a delete cannot.

Where the lookup cannot prove it would land on the same physical copy the scan itself would act on,
it declines and returns nothing rather than guessing. A Message-ID whose copies span two accounts is
never accelerated, because which copy the scan picks is decided by `Mail.accounts()` order and the
index does not record it. A contested Message-ID inside one account is accelerated only when its
head wins under both an exact and a case-folded reading of Mail's own by-name matching, and only
that certified head is emitted, so the JXA loop cannot drift onto a copy nothing certified. Two
copies in one mailbox are declined outright. Every decline is simply today's behaviour: the scan
answers, one round slower.

Each command gains `--engine`, defaulting to `auto`: `jxa` builds no locator and scans, `auto` uses
the lookup when the index opens and degrades silently to the scan when it does not, and `sqlite`
reports a missing Full Disk Access grant instead of quietly running slow. Batch responses carry a
`_lookup` summary unconditionally; per-message detail sits behind `MAIL_CLI_DEBUG=1`. Three documents
that described a clean reads-touch-SQLite / writes-touch-only-JXA split are corrected in the same
PR. Nine files, +2407 / −131.

## Performance

This is a performance change, not a behavioural one — the same message is located, and the same
Mail.app call acts on it.

Apple M4 (Mac16,10), macOS 26.5.2, Mail 16.0, against a live Envelope Index of roughly 192,000
messages. No row compares an old build against a new one: the wall-clock rows are one binary run
twice, `--engine jxa` against `--engine auto`.

| Command | Scan (`--engine jxa`) | Row-id (`--engine auto`) | Basis |
|---|---|---|---|
| `update`, 1 message | 4.37 s | 1.27 s | process wall clock |
| `batch-update`, 10 messages | 23.37 s | 3.42 s | process wall clock |
| `batch-update`, revert of the same 10 | 19.3 s | 2.75 s | process wall clock |
| `move`, `delete`, `batch-delete` | 3.8–4.4 s | 96–127 ms | per-operation find-and-act as timed by the command; range across a live sweep of ~90 write operations covering 37 of 40 command×account cells, including same-message both-engine comparisons |

*Scale, honestly:* the win scales with mailbox size, and on a small enough target it inverts — a
`delete` in a 3-message folder is 0.17 s by scan against 1.16 s on the fast path, and a `move` in a
20-message account 0.23 s against 0.48 s. The fast path pays a fixed index query; the scan pays for
whatever it has to walk.

*Build:* measured with `MAIL_CLI_DEBUG=1` on a build of this branch five commits before the head;
those five change only debug-gated telemetry and comments, and an independent audit byte-compared
the non-debug emitted scripts as identical, so the numbers hold for the submitted tree.

## Tests we ran to validate

| What is asserted | How it is checked |
|---|---|
| A row-id hit is accepted only if the message's own Message-ID matches the one requested | mutation-proven: hoisting the accept above the compare reddens exactly one named test |
| `move`, `delete` and `batch-delete` re-read the message before acting and refuse if it drifted — and the flag writes deliberately do not | mutation-proven twice (blanking the compare; hoisting the delete out of its guarded arm), with the absence on the flag path pinned as firmly as the presence |
| Only the certified head candidate is ever emitted to JXA | mutation-proven: emitting the whole ranked list reddens exactly one test |
| A Message-ID with copies in two accounts is not accelerated at all | pinned, alongside green counter-tests that fail if the decline is drawn too wide |
| No candidate mailbox is ever resolved by name | mutation-proven: re-emitting a mailbox path for JXA to match on reddens exactly one test |
| The emitted finder actually behaves: row-id hit, stale row-id fall-through, identity-mismatch fall-through | run headless in node against a fake Mail object reproducing the probed semantics — no Apple Events, no permission grant; the finder and all five full command scripts also pass `node --check` in both debug modes |
| The whole suite is green | 235 XCTest and 132 swift-testing tests in 11 suites, 0 failures; also green with `MAIL_CLI_DEBUG=1`; no test contacts Mail.app or `osascript` |
| The five commands do the right thing against real mail | all five executed against all 8 real accounts — Exchange, Gmail, iCloud, Yahoo — about 90 write operations covering 37 of 40 command×account cells, zero wrong-message effects, every touched message re-read and verified intact afterwards |
| Sustained use does not drift | first 18 hours of production use, on an earlier build of this branch: 280 row-id hits, 0 Message-ID mismatches, 0 fallbacks, 0 not-founds |

## Design decisions

**Why verify the Message-ID after every row-id hit.** The row-id → message mapping is an inference
from an on-disk index that Mail owns and this code never writes; if it were ever wrong, the failure
is a write landing on the wrong message, which is unrecoverable for `delete`. So every hit is
re-read and compared before any write, and a mismatch is counted and falls through to the scan.
Trusting the row-id instead reddens `testUnifiedFinderVerifiesTheMessageIdBeforeAcceptingAByIdHit`.

**Why a second, pre-write re-read only on the destructive three.** The identity check happens at
lookup time; a message can still move or vanish before the write. Another round-trip is worth paying
where the operation is irreversible and not where it is a flag flip, so the absence is pinned as
firmly as the presence: `testDestructiveCommandScriptsRefuseToActOnADriftedMessageId` covers the
three (compare span and act span), `testFlagUpdateScriptsCarryNoPreOpReReadByDesign` the flag path.

**Why decline a cross-account Message-ID rather than reproduce the scan's order.** Which physical
copy a write acts on is decided by sweep order, and the shipping finders sweep account-outer using
`Mail.accounts()` order, which the Envelope Index does not carry. The two subsystems agree on the
*set* of accounts — ids and display names matched for all eight on the probed machine — but that
says nothing about the *order*, so any reproduction would be a guess dressed as a lookup. Pinned by
`testAMessageIdPresentInTwoAccountsIsNotAcceleratedAtAll`; the sweep nesting itself by
`testBothShippedFindersSweepAccountOuterNotPriorityOuter`.

**Why emit only the certified head.** The certification proves the head is the copy the scan would
reach first, but the emitted loop `continue`s past a candidate on three paths the design treats as
normal, so a tail entry could be written to with nothing certifying it. The tail only ever bought
speed on a stale head, and a head miss falls through to the scan, which is today's behaviour.
Reverting to whole-list emission reddens `testACertifiedContestedIdEmitsTheCERTIFIEDHEADALONE`.

**Why address the row-id through any mailbox of the account, then re-anchor before acting.**
`mailbox.messages.byId(n)` is keyed to `messages.ROWID` and is mailbox-independent for property
access — probed on Gmail, Exchange and iCloud accounts — so the arm takes any mailbox handle the
account exposes and lets the identity check decide. Acting is stricter: `delete` and `move`
re-resolve the specifier's container chain, hence the re-anchor before the hit is counted. Resolving
the candidate's mailbox by leaf name was rejected — it assumes the folder name in the index is what
`mailbox.name()` reports, which fails on Gmail, where an earlier form of this arm silently never
engaged at all. Pinned by `testUnifiedFinderNeverLooksACandidateMailboxUpByName` and
`testUnifiedFinderReAnchorsTheAcceptedSpecifierThroughTheMessagesOwnMailbox`.

**Why not perform the write itself in SQLite.** No test can go red for this one, because no such
path was ever written — there is no write SQL anywhere in the change. Writing to Mail's own database
behind its back would put the app's in-memory state and its index out of agreement, and is not
something a plugin should do. The claim here is narrower: the index is a faster way to *find* the
message that Mail.app is then asked to change.

**Why `--engine` means something different on a write command.** On reads it selects which engine
produces the answer; on writes only how the message is *found*, since SQLite performs no part of the
write — so the help text is deliberately parallel but not identical, and "fail loud" for `sqlite`
means refuse to run degraded, never refuse to write. Nothing pins either help string, so this is a
convention argument, not a tested one.

**Why `_lookup` is underscore-prefixed, and why the batch summary is unconditional.** The underscore
marks diagnostic metadata about *how* the command worked, beside result keys describing *what* it
did; a bare `lookup` would read as another field of the result, and batch responses reach
agent-visible tool output unfiltered. The summary is unconditional because this fast path fails
silently and correctly: when it does not engage the answer is still right and the only symptom is
slowness — exactly how the Gmail name-matching miss above stayed invisible until someone read the
counters. Un-gating per-message detail reddens
`testPerMessageLookupDetailIsEmittedOnlyBehindTheDebugGate`; gating the aggregate reddens
`testBothBatchScriptsEmitTheLocatorSummaryUnconditionally`.

## Known limitations

- **Ambiguous destination names.** A `move` destination is resolved by name against the account's
  mailboxes, first match wins. Where several share that name — observed in the wild: four
  identically-named folders in one Exchange account — the move deterministically targets the first,
  and the response cannot say which. Pre-existing; a follow-up will make the ambiguous case fail loud.
- **Gmail move semantics.** On Gmail, a `move` to a label mailbox is a label *add*: the source label
  is retained and the response reports `moved:true`. A move to All Mail is an archive, stripping the
  inbox label. Trash and Spam are true moves. There is no label-remove primitive, so a label add
  cannot be undone here. Measured identically on both engines — inherited, documented not changed.
- **`reply` and `save-attachment` are not accelerated** — deliberate scope; "the five write commands"
  throughout means the five that are.
- **Declines are counted as fallbacks and are not distinguishable in telemetry** — a decline reads
  identically to "SQLite matched nothing", so fallbacks in a run are not evidence of a defect.
- **`local://` and `file://` copies are excluded from candidates** — Mail exposes no such account to
  scripting, so they are unreachable by either path; the account listing already skips them.
- **The probed semantics come from one macOS/Mail version** — if a future release changed `byId`
  or the account id/name agreement, the identity check turns it into a mismatch and a fall-through
  rather than a wrong write, but the acceleration would silently disappear.
- **Nothing headless can observe a `run()` body**, since it requires Mail.app to be running — the
  commands' use of the shared seam rests on that seam's own pin plus one visible call line each.
- **`--engine sqlite` is fail-loud about an unreadable index, not about an unresolvable account
  name** — a name that does not resolve degrades to the scan, keeping a hint-shaped input from
  failing a write the scan could still complete.
- **`--account` matches more forms on the fast path than the scan does** — the lookup resolves
  display name, user name or raw UUID; the scan's hint matches `account.name()` only. A
  user-name-shaped `--account` can therefore succeed under `auto` and report not-found under
  `jxa`. Stated in the code where the filter lives.
- **A bracketed `--id` (`<id>`) resolves on the fast path but not in the scan** — the lookup
  queries both header forms; the scan compares Mail's unbracketed `messageId` verbatim, as it
  always has.

## Repo checks

- No `lib/` or `mcp-server/` source touched → `mcp-server/dist/server.js` is intentionally not
  rebuilt: the JS handler layer never passes an engine flag, and the new option defaults to `auto`.
- No version source touched → `Version Consistency` passes trivially; no bump is claimed.
- `commands/mail.md` is deliberately untouched: it documents no `--engine` flag for any command, on
  either side of the read/write split.
- Code hygiene: no hardcoded user paths, no personal addresses, no secrets, no PII; fixtures are
  synthetic.

## Related

- Builds on **#105** (merged): this reads the same Envelope Index through the IMAP account-name
  resolution and Gmail label-scoping fixes that landed there.
- **#106** is an open issue we filed about read-side edge defects. It is mentioned only so the two
  are not confused — this PR neither depends on it nor addresses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
