### PR TITLE
fix(plugin): declare openclaw as a peer dependency

### DIFF
--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -84,14 +84,22 @@
   },
   "dependencies": {
     "mailparser": "^3.9.3",
-    "openclaw": "^2026.6.5",
     "turndown": "^7.2.2"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.6.5"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
   },
   "main": "./dist/index.js",
   "devDependencies": {
     "typescript": "^5.9.3",
     "@types/node": "^25.5.0",
     "@types/mailparser": "^3.4.6",
-    "tsup": "^8.5.0"
+    "tsup": "^8.5.0",
+    "openclaw": ">=2026.6.5"
   }
 }


### PR DESCRIPTION
## Problem

`openclaw/package.json` declared the host package as a runtime dependency:

```json
"dependencies": {
  "mailparser": "^3.9.3",
  "openclaw": "^2026.6.5",
  "turndown": "^7.2.2"
}
```

The plugin imports the host SDK across 9 source files (`src/index.ts`,
`src/mail-channel/{entry,inbound,dispatch,send-approval,sdk-compat.assert}.ts`,
`src/mail-auth/strength.ts`, plus tests) via `openclaw/plugin-sdk/plugin-entry`,
`.../channel-core`, `.../channel-ingress-runtime`, `.../config-contracts`, and
`.../reply-dispatch-runtime`. That is exactly the case the host docs call out.

`docs/plugins/dependency-resolution.md` in openclaw states:

> Plugins that import `openclaw/plugin-sdk/*` declare `openclaw` as a peer
> dependency. OpenClaw does not let npm install a separate registry copy of the
> host package into a managed project, because a stale host package can affect
> npm's peer resolution inside that plugin.

Two concrete consequences:

1. **Vendored second host.** A full copy of openclaw (~363 MB) gets installed
   into the plugin, pinned at `2026.6.5`, while the gateway actually runs
   `2026.8.1-beta.2`. Two host versions in one process is a resolution hazard.
2. **Fragile plugin load.** A global `npm i -g openclaw@beta` can remove the
   vendored copy, after which the plugin fails to load with
   `cannot load because required dependencies are missing: openclaw`.

## Fix

Move `openclaw` out of `dependencies`:

- `peerDependencies`: `"openclaw": ">=2026.6.5"` — preserves the original floor
  from the `^2026.6.5` range.
- `peerDependenciesMeta`: `openclaw` marked `optional: true`, so npm does not
  force-install the host into consumers.
- `devDependencies`: `"openclaw": ">=2026.6.5"` — local builds, `tsup`, and
  type-checking still resolve `openclaw/plugin-sdk/*`.

`mailparser` and `turndown` are genuine runtime dependencies and stay in
`dependencies`.

This mirrors the same transformation landed in
[omarshahine/fastmail-mcp-remote#63](https://github.com/omarshahine/fastmail-mcp-remote/pull/63).

## Verification

- Branched from `origin/main` (not the in-flight `omarshahine/rfc-0028-kernel-swap` branch).
- `npm install` in `openclaw/` succeeded (npm audit / allow-scripts warnings are pre-existing and unrelated).
- SDK still resolves locally:
  ```
  $ node -e "console.log(require('./node_modules/openclaw/package.json').version)"
  2026.6.5
  ```
- `package-lock.json` is gitignored in this repo, so only `package.json` is in the diff.
- Gateway restart and the plugin smoke suite are intentionally **not** run here; they are handled centrally in a later phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019R9efVheM5Xrttavbw5i4s
