### PR TITLE
fix(helper): launch PIMHelper.app via a Mach-O stub, not a shell script

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "apple-pim",
       "source": "./",
       "description": "Native macOS integration for Calendar, Reminders, Contacts, and Mail using EventKit, Contacts, and JXA frameworks",
-      "version": "3.11.1",
+      "version": "3.11.3",
       "keywords": [
         "calendar",
         "reminders",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim",
-  "version": "3.11.1",
+  "version": "3.11.3",
   "description": "Native macOS integration for Calendar, Reminders, Contacts, and Mail using EventKit, Contacts, and JXA frameworks",
   "author": {
     "name": "Omar Shahine",

--- a/helper/launcher.c
+++ b/helper/launcher.c
@@ -1,0 +1,77 @@
+// Mach-O launcher for PIMHelper.app.
+//
+// Why this exists: macOS refuses to launch an application bundle whose
+// CFBundleExecutable is a shell script. LaunchServices rejects it before the
+// script ever runs, with:
+//
+//     _LSOpenURLsWithCompletionHandler() failed for the application
+//     ~/Applications/PIMHelper.app with error -10669
+//
+// -10669 sits in the LaunchServices reserved range whose documented
+// neighbours are all "this executable cannot run here" errors
+// (kLSExecutableIncorrectFormat = -10661, kLSIncompatibleApplicationVersionErr
+// = -10664). It reproduces with a minimal, unsigned, freshly-created bundle
+// containing nothing but a two-line zsh script, so it is a property of script
+// bundles on current macOS, not of this bundle's contents or signature.
+//
+// The helper still needs to be a real .app: the whole point is that
+// LaunchServices makes the bundle the TCC-responsible process, so Calendar /
+// Reminders / Contacts prompts fire against the helper's bundle id instead of
+// whatever shell the agent runtime happens to use. So rather than abandon the
+// design, this tiny executable becomes CFBundleExecutable and re-execs the
+// real dispatcher script from Contents/Resources, forwarding argv verbatim.
+// execv replaces this process image, so the script inherits the bundle's
+// responsible-process identity exactly as before.
+
+#include <libgen.h>
+#include <limits.h>
+#include <mach-o/dyld.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define SCRIPT_RELATIVE_PATH "/../Resources/pim-helper.sh"
+
+int main(int argc, char *argv[]) {
+  char executable_path[PATH_MAX];
+  uint32_t size = sizeof(executable_path);
+  if (_NSGetExecutablePath(executable_path, &size) != 0) {
+    fprintf(stderr, "pim-helper: executable path exceeds PATH_MAX\n");
+    return 71; // EX_OSERR
+  }
+
+  // Resolve symlinks so dirname() yields the real Contents/MacOS directory.
+  char resolved_path[PATH_MAX];
+  if (realpath(executable_path, resolved_path) == NULL) {
+    perror("pim-helper: realpath");
+    return 71;
+  }
+
+  char script_path[PATH_MAX];
+  int written = snprintf(script_path, sizeof(script_path), "%s%s",
+                         dirname(resolved_path), SCRIPT_RELATIVE_PATH);
+  if (written < 0 || (size_t)written >= sizeof(script_path)) {
+    fprintf(stderr, "pim-helper: script path exceeds PATH_MAX\n");
+    return 71;
+  }
+
+  // argv layout for zsh: ["/bin/zsh", script, <forwarded args...>, NULL].
+  char **args = calloc((size_t)argc + 2, sizeof(char *));
+  if (args == NULL) {
+    perror("pim-helper: calloc");
+    return 71;
+  }
+  args[0] = "/bin/zsh";
+  args[1] = script_path;
+  for (int i = 1; i < argc; i++) {
+    args[i + 1] = argv[i];
+  }
+
+  execv("/bin/zsh", args);
+
+  // execv only returns on failure.
+  perror("pim-helper: execv");
+  free(args);
+  return 71;
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim-mcp",
-  "version": "3.11.1",
+  "version": "3.11.3",
   "description": "MCP server for Apple PIM, a Personal Information Manager for Calendar, Reminders, Contacts, and Mail",
   "type": "module",
   "main": "dist/server.js",

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -92,7 +92,7 @@
       }
     }
   },
-  "version": "3.11.1",
+  "version": "3.11.3",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim-cli",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "description": "OpenClaw plugin for macOS Calendar, Reminders, Contacts, and Mail. macOS-only; depends on four native Swift CLIs (calendar-cli, reminder-cli, contacts-cli, mail-cli) you build locally from source via ./setup.sh. The registry does not download or install binaries.",
   "type": "module",
   "scripts": {

--- a/scripts/build-helper-app.sh
+++ b/scripts/build-helper-app.sh
@@ -37,11 +37,12 @@ if [[ ! -f "$SRC_DIR/Info.plist" || ! -f "$SRC_DIR/pim-helper" || ! -f "$SRC_DIR
     exit 1
 fi
 
-if ! command -v cc >/dev/null 2>&1; then
-    echo "build-helper-app: no C compiler found; install Xcode Command Line Tools" >&2
-    echo "build-helper-app: (xcode-select --install)" >&2
-    exit 1
-fi
+# Hash of the launcher source that produced the installed binary. Written into
+# the bundle at build time so the freshness check below can tell whether the
+# compiled CFBundleExecutable is still current: the source is C and the install
+# is a binary, so they cannot be compared with cmp.
+LAUNCHER_STAMP_REL="Contents/Resources/.launcher-source-sha256"
+launcher_source_hash() { shasum -a 256 "$SRC_DIR/launcher.c" | awk '{print $1}'; }
 
 # True when the installed bundle's signature matches the requested identity.
 # Ad-hoc shows as `Signature=adhoc` (no Authority line); a certificate shows
@@ -65,10 +66,20 @@ installed_identity_matches() {
 if [[ "$FORCE" != true && -d "$APP_PATH" ]] \
     && cmp -s "$SRC_DIR/Info.plist" "$APP_PATH/Contents/Info.plist" \
     && cmp -s "$SRC_DIR/pim-helper" "$APP_PATH/Contents/Resources/pim-helper.sh" \
+    && [[ "$(cat "$APP_PATH/$LAUNCHER_STAMP_REL" 2>/dev/null)" == "$(launcher_source_hash)" ]] \
     && codesign --verify "$APP_PATH" >/dev/null 2>&1 \
     && { [[ -z "${APPLE_PIM_SIGN_IDENTITY:-}" ]] || installed_identity_matches; }; then
     echo "PIMHelper.app is up to date at: $APP_PATH (leaving untouched to preserve TCC grants)"
     exit 0
+fi
+
+# Only required once we know a rebuild is actually happening. Checking earlier
+# would fail an otherwise-successful no-op install on a host without developer
+# tools, which is a regression against the pre-launcher behaviour.
+if ! command -v cc >/dev/null 2>&1; then
+    echo "build-helper-app: no C compiler found; install Xcode Command Line Tools" >&2
+    echo "build-helper-app: (xcode-select --install)" >&2
+    exit 1
 fi
 
 if [[ -d "$APP_PATH" ]]; then
@@ -102,6 +113,10 @@ chmod +x "$APP_PATH/Contents/Resources/pim-helper.sh"
 # but resolve its own path and execv into /bin/zsh.
 cc -Os -Wall -Wextra -o "$APP_PATH/Contents/MacOS/pim-helper" "$SRC_DIR/launcher.c"
 chmod +x "$APP_PATH/Contents/MacOS/pim-helper"
+
+# Record which launcher source built this binary so the freshness check above
+# can detect launcher.c changes on a later run.
+launcher_source_hash > "$APP_PATH/$LAUNCHER_STAMP_REL"
 
 # Sign the bundle. --force overwrites any prior signature; --deep walks
 # contents (the bundle is shallow but this future-proofs nested files).

--- a/scripts/build-helper-app.sh
+++ b/scripts/build-helper-app.sh
@@ -32,8 +32,14 @@ SIGN_IDENTITY="${APPLE_PIM_SIGN_IDENTITY:--}"
 FORCE=false
 [[ "${1:-}" == "--force" ]] && FORCE=true
 
-if [[ ! -f "$SRC_DIR/Info.plist" || ! -f "$SRC_DIR/pim-helper" ]]; then
+if [[ ! -f "$SRC_DIR/Info.plist" || ! -f "$SRC_DIR/pim-helper" || ! -f "$SRC_DIR/launcher.c" ]]; then
     echo "build-helper-app: missing helper sources at $SRC_DIR" >&2
+    exit 1
+fi
+
+if ! command -v cc >/dev/null 2>&1; then
+    echo "build-helper-app: no C compiler found; install Xcode Command Line Tools" >&2
+    echo "build-helper-app: (xcode-select --install)" >&2
     exit 1
 fi
 
@@ -58,7 +64,7 @@ installed_identity_matches() {
 # downgraded (which would drop the grants).
 if [[ "$FORCE" != true && -d "$APP_PATH" ]] \
     && cmp -s "$SRC_DIR/Info.plist" "$APP_PATH/Contents/Info.plist" \
-    && cmp -s "$SRC_DIR/pim-helper" "$APP_PATH/Contents/MacOS/pim-helper" \
+    && cmp -s "$SRC_DIR/pim-helper" "$APP_PATH/Contents/Resources/pim-helper.sh" \
     && codesign --verify "$APP_PATH" >/dev/null 2>&1 \
     && { [[ -z "${APPLE_PIM_SIGN_IDENTITY:-}" ]] || installed_identity_matches; }; then
     echo "PIMHelper.app is up to date at: $APP_PATH (leaving untouched to preserve TCC grants)"
@@ -82,9 +88,19 @@ if [[ -e "$APP_PATH" ]]; then
     fi
 fi
 
-mkdir -p "$APP_PATH/Contents/MacOS"
+mkdir -p "$APP_PATH/Contents/MacOS" "$APP_PATH/Contents/Resources"
 cp "$SRC_DIR/Info.plist" "$APP_PATH/Contents/Info.plist"
-cp "$SRC_DIR/pim-helper" "$APP_PATH/Contents/MacOS/pim-helper"
+
+# The dispatcher script lives in Resources, NOT as CFBundleExecutable: macOS
+# refuses to launch an .app whose main executable is a shell script (see
+# helper/launcher.c). CFBundleExecutable is a compiled launcher that re-execs
+# this script, so the bundle still becomes the TCC-responsible process.
+cp "$SRC_DIR/pim-helper" "$APP_PATH/Contents/Resources/pim-helper.sh"
+chmod +x "$APP_PATH/Contents/Resources/pim-helper.sh"
+
+# Build for the running architecture. -Os keeps the stub tiny; it does nothing
+# but resolve its own path and execv into /bin/zsh.
+cc -Os -Wall -Wextra -o "$APP_PATH/Contents/MacOS/pim-helper" "$SRC_DIR/launcher.c"
 chmod +x "$APP_PATH/Contents/MacOS/pim-helper"
 
 # Sign the bundle. --force overwrites any prior signature; --deep walks


### PR DESCRIPTION
## Problem

macOS refuses to launch an application bundle whose `CFBundleExecutable` is a shell script. Every launch of `PIMHelper.app` fails inside LaunchServices before the script ever runs:

```
_LSOpenURLsWithCompletionHandler() failed for the application
/Users/<user>/Applications/PIMHelper.app with error -10669
```

`-10669` sits in LaunchServices' reserved range, and its documented neighbours are all "this executable cannot run here" errors — `kLSExecutableIncorrectFormat` (-10661), `kLSIncompatibleApplicationVersionErr` (-10664).

**It is not this bundle.** I reproduced the identical error with a minimal, unsigned, freshly-created bundle containing nothing but a two-line zsh script and an Info.plist. `codesign --verify` passes on PIMHelper throughout ("valid on disk, satisfies its Designated Requirement"), and `lsregister -f` does not help. It is a property of script bundles on current macOS.

## Why it matters

Reminders breaks whenever the calling runtime has no Reminders TCC entry of its own, because the helper fallback cannot start.

That is not an edge case. TCC grants are keyed to the interpreter's **absolute path**, and Homebrew pins node per version:

| Service | node 25.6.0 | node 26.0.0 | node 26.5.0 |
|---|---|---|---|
| Calendar | granted | granted | granted |
| AddressBook | granted | granted | granted |
| **Reminders** | granted | granted | **no row** |

A routine `brew upgrade node` silently drops the grant, and the helper — the thing designed to survive exactly this — cannot launch to cover for it. Calendar and Contacts keep working, so it presents as "only Reminders is broken", which is a confusing place to start debugging.

## Fix

Keep the design, fix the mechanism. `CFBundleExecutable` becomes a small compiled launcher that resolves its own path and `execv()`s the real dispatcher, now installed at `Contents/Resources/pim-helper.sh`.

`execv` replaces the process image rather than forking, so the script still inherits the bundle's responsible-process identity and TCC still attributes prompts to the helper's bundle id. The dispatcher script itself is unchanged.

`scripts/build-helper-app.sh` now compiles `helper/launcher.c` with `cc`, installs the script into `Contents/Resources/`, and compares against that path for its idempotency check (which exists to avoid re-signing and dropping TCC grants). It fails with an actionable message if no C compiler is present.

## Verification

On macOS 26 (Darwin 25.4, arm64):

- `codesign -dvvv` now reports `Format=app bundle with Mach-O thin (arm64)` instead of a script bundle.
- `open -W -a PIMHelper.app --args reminder-cli <out> <err> lists` launches successfully — no `-10669`.
- Process tree confirms the stub exec'd correctly with argv forwarded intact:

```
/bin/zsh /Users/<user>/Applications/PIMHelper.app/Contents/MacOS/../Resources/pim-helper.sh reminder-cli <out> <err> lists
```

- The Reminders permission prompt then fires against the helper's bundle id — which it could never do before, because the app could not start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019R9efVheM5Xrttavbw5i4s