### PR TITLE
fix(reminders): keep start dates synced to due dates (v3.12.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "apple-pim",
       "source": "./",
       "description": "Native macOS integration for Calendar, Reminders, Contacts, and Mail using EventKit, Contacts, and JXA frameworks",
-      "version": "3.11.3",
+      "version": "3.12.0",
       "keywords": [
         "calendar",
         "reminders",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim",
-  "version": "3.11.3",
+  "version": "3.12.0",
   "description": "Native macOS integration for Calendar, Reminders, Contacts, and Mail using EventKit, Contacts, and JXA frameworks",
   "author": {
     "name": "Omar Shahine",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim-mcp",
-  "version": "3.11.3",
+  "version": "3.12.0",
   "description": "MCP server for Apple PIM, a Personal Information Manager for Calendar, Reminders, Contacts, and Mail",
   "type": "module",
   "main": "dist/server.js",

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "apple-pim-cli",
   "name": "Apple PIM: Calendar, Reminders, Contacts, Mail",
-  "description": "macOS-only. Wraps four native Swift CLIs (calendar-cli, reminder-cli, contacts-cli, mail-cli) you build locally from source via ./setup.sh \u2014 no binaries are downloaded by the registry. Grants the agent read/write access to Calendar, Reminders, Contacts, and Mail.app (including send/delete) once you approve the corresponding macOS TCC and Automation prompts.",
+  "description": "macOS-only. Wraps four native Swift CLIs (calendar-cli, reminder-cli, contacts-cli, mail-cli) you build locally from source via ./setup.sh — no binaries are downloaded by the registry. Grants the agent read/write access to Calendar, Reminders, Contacts, and Mail.app (including send/delete) once you approve the corresponding macOS TCC and Automation prompts.",
   "channels": [
     "apple-mail"
   ],
@@ -92,7 +92,7 @@
       }
     }
   },
-  "version": "3.11.3",
+  "version": "3.12.0",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim-cli",
-  "version": "3.11.3",
+  "version": "3.12.0",
   "description": "OpenClaw plugin for macOS Calendar, Reminders, Contacts, and Mail. macOS-only; depends on four native Swift CLIs (calendar-cli, reminder-cli, contacts-cli, mail-cli) you build locally from source via ./setup.sh. The registry does not download or install binaries.",
   "type": "module",
   "scripts": {

--- a/swift/Sources/ReminderCLI/ReminderCLI.swift
+++ b/swift/Sources/ReminderCLI/ReminderCLI.swift
@@ -1307,10 +1307,17 @@ func mirroredStart(from due: DateComponents) -> DateComponents {
     return start
 }
 
-func sameInstant(_ a: DateComponents?, _ b: DateComponents?) -> Bool {
+/// Whether two date components would be stored identically by EventKit.
+///
+/// The time zone is part of the comparison. Matching wall-clock fields with
+/// differing zones is exactly the state that makes EventKit renormalize both
+/// the start and due dates on the next save, so `repair-dates` must treat it
+/// as drift rather than skipping it.
+func sameStoredDate(_ a: DateComponents?, _ b: DateComponents?) -> Bool {
     guard let a, let b else { return a == nil && b == nil }
     return a.year == b.year && a.month == b.month && a.day == b.day
         && (a.hour ?? 0) == (b.hour ?? 0) && (a.minute ?? 0) == (b.minute ?? 0)
+        && a.timeZone == b.timeZone
 }
 
 /// Repairs reminders whose start date drifted away from their due date.
@@ -1371,7 +1378,7 @@ struct RepairDates: AsyncParsableCommand {
             }
 
             let desired = mirroredStart(from: due)
-            if sameInstant(reminder.startDateComponents, desired) { continue }
+            if sameStoredDate(reminder.startDateComponents, desired) { continue }
 
             var change: [String: Any] = [
                 "id": reminder.calendarItemIdentifier,
@@ -1380,6 +1387,8 @@ struct RepairDates: AsyncParsableCommand {
                 "dueDate": dateComponentsToString(due),
                 "oldStartDate": reminder.startDateComponents.map { dateComponentsToString($0) } ?? "none",
                 "newStartDate": dateComponentsToString(desired),
+                "dueTimeZone": due.timeZone?.identifier ?? "none",
+                "oldStartTimeZone": reminder.startDateComponents?.timeZone?.identifier ?? "none",
                 "recurring": reminder.hasRecurrenceRules
             ]
 

--- a/swift/Sources/ReminderCLI/ReminderCLI.swift
+++ b/swift/Sources/ReminderCLI/ReminderCLI.swift
@@ -22,6 +22,7 @@ struct ReminderCLI: AsyncParsableCommand {
             BatchCreateReminder.self,
             BatchCompleteReminder.self,
             BatchDeleteReminder.self,
+            RepairDates.self,
             ConfigCommand.self,
         ]
     )
@@ -190,9 +191,6 @@ func reminderToDict(_ reminder: EKReminder) -> [String: Any] {
     if let dueDate = reminder.dueDateComponents {
         dict["dueDate"] = dateComponentsToString(dueDate)
     }
-    if let startDate = reminder.startDateComponents {
-        dict["startDate"] = dateComponentsToString(startDate)
-    }
     if let notes = reminder.notes, !notes.isEmpty {
         dict["notes"] = notes
     }
@@ -222,6 +220,27 @@ func dateComponentsToString(_ components: DateComponents) -> String {
     }
 
     return dateStr
+}
+
+/// Sets a reminder's date, keeping `startDateComponents` mirrored to
+/// `dueDateComponents`.
+///
+/// Reminders.app writes both fields together and offers no separate "start
+/// date" control, but EventKit does not mirror them for you. Writing due
+/// alone leaves whatever start date was there before, and a reminder that
+/// ends up with a start date but no due date renders as *dateless* in
+/// Reminders.app while still occupying a date slot in EventKit. Always go
+/// through this instead of assigning `dueDateComponents` directly.
+func setReminderDate(_ reminder: EKReminder, to components: DateComponents?) {
+    reminder.dueDateComponents = components
+    reminder.startDateComponents = components
+}
+
+/// Sets only the due date, mirroring start to match. Preserves the incoming
+/// time zone on both fields.
+func setReminderDueDate(_ reminder: EKReminder, to due: DateComponents?) {
+    reminder.dueDateComponents = due
+    reminder.startDateComponents = due.map { mirroredStart(from: $0) }
 }
 
 func ruleToDict(_ rule: EKRecurrenceRule) -> [String: Any] {
@@ -737,7 +756,7 @@ struct CreateReminder: AsyncParsableCommand {
         reminder.calendar = try resolveTargetList(explicit: list, config: config)
 
         if let dueStr = due, let dueDate = parseDate(dueStr) {
-            reminder.dueDateComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: dueDate)
+            setReminderDate(reminder, to: Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: dueDate))
         }
 
         if let n = notes {
@@ -865,7 +884,7 @@ struct UpdateReminder: AsyncParsableCommand {
         }
         if let newDue = due {
             if let dueDate = parseDate(newDue) {
-                reminder.dueDateComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: dueDate)
+                setReminderDate(reminder, to: Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: dueDate))
             }
         }
         if let newNotes = notes {
@@ -1015,7 +1034,7 @@ struct BatchCreateReminder: AsyncParsableCommand {
                 reminder.title = reminderInput.title
                 reminder.calendar = try resolveTargetList(explicit: reminderInput.list, config: config)
 
-                reminder.dueDateComponents = batchReminderDueDateComponents(reminderInput.due)
+                setReminderDate(reminder, to: batchReminderDueDateComponents(reminderInput.due))
 
                 if let n = reminderInput.notes {
                     reminder.notes = n
@@ -1242,6 +1261,134 @@ struct BatchDeleteReminder: AsyncParsableCommand {
 }
 
 // MARK: - Config Command
+
+// MARK: - Repair Dates
+
+/// Returns the `startDateComponents` value that should accompany `due`.
+///
+/// Reminders.app stores an all-day reminder as a due date with no time and a
+/// start date at 00:00, so an exact component copy is not quite right. This
+/// mirrors the day fields and fills in midnight when the due date carries no
+/// time of day.
+func mirroredStart(from due: DateComponents) -> DateComponents {
+    var start = DateComponents()
+    start.year = due.year
+    start.month = due.month
+    start.day = due.day
+    start.hour = due.hour ?? 0
+    start.minute = due.minute ?? 0
+    // Carry the due date's time zone across. Handing EventKit a start date
+    // with no time zone makes it renormalize BOTH fields into local time on
+    // save, which silently rewrites the due date's wall-clock representation.
+    start.timeZone = due.timeZone
+    return start
+}
+
+func sameInstant(_ a: DateComponents?, _ b: DateComponents?) -> Bool {
+    guard let a, let b else { return a == nil && b == nil }
+    return a.year == b.year && a.month == b.month && a.day == b.day
+        && (a.hour ?? 0) == (b.hour ?? 0) && (a.minute ?? 0) == (b.minute ?? 0)
+}
+
+/// Repairs reminders whose start date drifted away from their due date.
+///
+/// Versions of this CLI before the `setReminderDate` fix wrote
+/// `dueDateComponents` without touching `startDateComponents`, leaving stale
+/// start dates behind. Reminders that ended up with a start date and no due
+/// date render as *dateless* in Reminders.app, and some third-party clients
+/// bucket them as due today.
+struct RepairDates: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "repair-dates",
+        abstract: "Re-sync reminder start dates to their due dates (dry run unless --apply)"
+    )
+
+    @OptionGroup var pimOptions: PIMOptions
+
+    @Flag(name: .long, help: "Write the changes. Without this the command only reports.")
+    var apply: Bool = false
+
+    @Flag(name: .long, help: "Include completed reminders")
+    var completed: Bool = false
+
+    func run() async throws {
+        try await requestReminderAccess()
+
+        let config = pimOptions.loadConfig()
+        var calendars: [EKCalendar]?
+        if config.reminders.mode != .all {
+            calendars = allowedLists(config: config)
+        }
+
+        let predicate = eventStore.predicateForReminders(in: calendars)
+        let reminders = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[EKReminder], Error>) in
+            eventStore.fetchReminders(matching: predicate) { continuation.resume(returning: $0 ?? []) }
+        }
+
+        var repaired: [[String: Any]] = []
+        var orphans: [[String: Any]] = []
+        var errors: [[String: Any]] = []
+        var scanned = 0
+
+        for reminder in reminders where completed || !reminder.isCompleted {
+            scanned += 1
+
+            // Start date but no due date: Reminders.app shows these as dateless.
+            // Picking a due date is a judgement call, so only report them.
+            guard let due = reminder.dueDateComponents else {
+                if let start = reminder.startDateComponents {
+                    orphans.append([
+                        "id": reminder.calendarItemIdentifier,
+                        "title": reminder.title ?? "",
+                        "list": reminder.calendar?.title ?? "",
+                        "startDate": dateComponentsToString(start)
+                    ])
+                }
+                continue
+            }
+
+            let desired = mirroredStart(from: due)
+            if sameInstant(reminder.startDateComponents, desired) { continue }
+
+            var change: [String: Any] = [
+                "id": reminder.calendarItemIdentifier,
+                "title": reminder.title ?? "",
+                "list": reminder.calendar?.title ?? "",
+                "dueDate": dateComponentsToString(due),
+                "oldStartDate": reminder.startDateComponents.map { dateComponentsToString($0) } ?? "none",
+                "newStartDate": dateComponentsToString(desired),
+                "recurring": reminder.hasRecurrenceRules
+            ]
+
+            if apply {
+                reminder.startDateComponents = desired
+                do {
+                    try eventStore.save(reminder, commit: false)
+                } catch {
+                    change["error"] = error.localizedDescription
+                    errors.append(change)
+                    continue
+                }
+            }
+            repaired.append(change)
+        }
+
+        if apply && !repaired.isEmpty {
+            try eventStore.commit()
+        }
+
+        outputJSON([
+            "success": errors.isEmpty,
+            "applied": apply,
+            "scanned": scanned,
+            "repairedCount": repaired.count,
+            "repaired": repaired,
+            "orphanedCount": orphans.count,
+            "orphaned": orphans,
+            "errors": errors
+        ])
+    }
+}
 
 struct ConfigCommand: ParsableCommand {
     static let configuration = CommandConfiguration(

--- a/swift/Sources/ReminderCLI/ReminderCLI.swift
+++ b/swift/Sources/ReminderCLI/ReminderCLI.swift
@@ -231,16 +231,41 @@ func dateComponentsToString(_ components: DateComponents) -> String {
 /// ends up with a start date but no due date renders as *dateless* in
 /// Reminders.app while still occupying a date slot in EventKit. Always go
 /// through this instead of assigning `dueDateComponents` directly.
-func setReminderDate(_ reminder: EKReminder, to components: DateComponents?) {
-    reminder.dueDateComponents = components
-    reminder.startDateComponents = components
-}
-
-/// Sets only the due date, mirroring start to match. Preserves the incoming
-/// time zone on both fields.
+/// Sets a reminder's due date and mirrors `startDateComponents` to match.
+///
+/// Reminders.app writes both fields together and offers no separate "start
+/// date" control, but EventKit does not mirror them for you. Writing due
+/// alone leaves whatever start date was there before, and a reminder that
+/// ends up with a start date but no due date renders as *dateless* in
+/// Reminders.app. Always go through this instead of assigning
+/// `dueDateComponents` directly.
 func setReminderDueDate(_ reminder: EKReminder, to due: DateComponents?) {
     reminder.dueDateComponents = due
     reminder.startDateComponents = due.map { mirroredStart(from: $0) }
+}
+
+/// Whether a due-date string names a day with no time of day.
+///
+/// Matched with an anchored regex rather than `DateFormatter`, which happily
+/// parses a *prefix*: "2026-09-01 07:00" satisfies a "yyyy-MM-dd" formatter
+/// and would otherwise be misread as all-day.
+func isDateOnlyString(_ string: String) -> Bool {
+    let trimmed = string.trimmingCharacters(in: .whitespaces)
+    let patterns = [#"^\d{4}-\d{1,2}-\d{1,2}$"#, #"^\d{1,2}/\d{1,2}/\d{4}$"#]
+    return patterns.contains { trimmed.range(of: $0, options: .regularExpression) != nil }
+}
+
+/// Builds due-date components, keeping the all-day shape when the caller
+/// named a day without a time.
+///
+/// Reminders.app stores an all-day reminder as a due date carrying no hour or
+/// minute. Someone passing "2027-06-01" means the whole day, not midnight.
+func reminderDueComponents(from string: String) -> DateComponents? {
+    guard let date = parseDate(string) else { return nil }
+    let fields: Set<Calendar.Component> = isDateOnlyString(string)
+        ? [.year, .month, .day]
+        : [.year, .month, .day, .hour, .minute]
+    return Calendar.current.dateComponents(fields, from: date)
 }
 
 func ruleToDict(_ rule: EKRecurrenceRule) -> [String: Any] {
@@ -755,8 +780,8 @@ struct CreateReminder: AsyncParsableCommand {
         reminder.title = title
         reminder.calendar = try resolveTargetList(explicit: list, config: config)
 
-        if let dueStr = due, let dueDate = parseDate(dueStr) {
-            setReminderDate(reminder, to: Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: dueDate))
+        if let dueStr = due, let components = reminderDueComponents(from: dueStr) {
+            setReminderDueDate(reminder, to: components)
         }
 
         if let n = notes {
@@ -883,8 +908,8 @@ struct UpdateReminder: AsyncParsableCommand {
             reminder.title = newTitle
         }
         if let newDue = due {
-            if let dueDate = parseDate(newDue) {
-                setReminderDate(reminder, to: Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: dueDate))
+            if let components = reminderDueComponents(from: newDue) {
+                setReminderDueDate(reminder, to: components)
             }
         }
         if let newNotes = notes {
@@ -1002,10 +1027,8 @@ func decodeBatchReminders(_ json: String) throws -> [BatchReminderInput] {
 }
 
 func batchReminderDueDateComponents(_ due: String?) -> DateComponents? {
-    guard let due, let dueDate = parseDate(due) else {
-        return nil
-    }
-    return Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: dueDate)
+    guard let due else { return nil }
+    return reminderDueComponents(from: due)
 }
 
 struct BatchCreateReminder: AsyncParsableCommand {
@@ -1034,7 +1057,7 @@ struct BatchCreateReminder: AsyncParsableCommand {
                 reminder.title = reminderInput.title
                 reminder.calendar = try resolveTargetList(explicit: reminderInput.list, config: config)
 
-                setReminderDate(reminder, to: batchReminderDueDateComponents(reminderInput.due))
+                setReminderDueDate(reminder, to: batchReminderDueDateComponents(reminderInput.due))
 
                 if let n = reminderInput.notes {
                     reminder.notes = n

--- a/swift/Tests/ReminderCLITests/StartDueSyncTests.swift
+++ b/swift/Tests/ReminderCLITests/StartDueSyncTests.swift
@@ -49,9 +49,9 @@ final class StartDueSyncTests: XCTestCase {
         XCTAssertNil(mirroredStart(from: due).timeZone)
     }
 
-    // MARK: - sameInstant
+    // MARK: - sameStoredDate
 
-    func testSameInstantTreatsMissingTimeAsMidnight() {
+    func testSameStoredDateTreatsMissingTimeAsMidnight() {
         var dateOnly = DateComponents()
         dateOnly.year = 2026; dateOnly.month = 12; dateOnly.day = 1
 
@@ -59,32 +59,69 @@ final class StartDueSyncTests: XCTestCase {
         midnight.hour = 0
         midnight.minute = 0
 
-        XCTAssertTrue(sameInstant(dateOnly, midnight))
+        XCTAssertTrue(sameStoredDate(dateOnly, midnight))
     }
 
-    func testSameInstantDetectsDifferentDay() {
+    func testSameStoredDateDetectsDifferentDay() {
         var a = DateComponents()
         a.year = 2026; a.month = 8; a.day = 18
         var b = a
         b.day = 1
-        XCTAssertFalse(sameInstant(a, b))
+        XCTAssertFalse(sameStoredDate(a, b))
     }
 
-    func testSameInstantDetectsDifferentTime() {
+    func testSameStoredDateDetectsDifferentTime() {
         var a = DateComponents()
         a.year = 2026; a.month = 9; a.day = 1
         a.hour = 7; a.minute = 0
         var b = a
         b.hour = 6
-        XCTAssertFalse(sameInstant(a, b))
+        XCTAssertFalse(sameStoredDate(a, b))
     }
 
-    func testSameInstantNilHandling() {
+    /// Regression (Greptile P1 on #111): matching wall-clock fields with
+    /// differing time zones is NOT the same stored date. Treating it as equal
+    /// made repair-dates skip exactly the drift that causes EventKit to
+    /// rewrite the due date on the next save.
+    func testSameStoredDateDetectsTimeZoneMismatch() {
+        var withZone = DateComponents()
+        withZone.year = 2026; withZone.month = 9; withZone.day = 3
+        withZone.hour = 9; withZone.minute = 30
+        withZone.timeZone = TimeZone(identifier: "America/New_York")
+
+        var withoutZone = withZone
+        withoutZone.timeZone = nil
+
+        var otherZone = withZone
+        otherZone.timeZone = TimeZone(identifier: "America/Los_Angeles")
+
+        XCTAssertFalse(sameStoredDate(withZone, withoutZone))
+        XCTAssertFalse(sameStoredDate(withZone, otherZone))
+        XCTAssertTrue(sameStoredDate(withZone, withZone))
+    }
+
+    /// A reminder whose start zone drifted from its due zone must be repaired
+    /// into a fixed point.
+    func testRepairingTimeZoneMismatchConverges() {
+        var due = DateComponents()
+        due.year = 2026; due.month = 9; due.day = 3
+        due.hour = 9; due.minute = 30
+        due.timeZone = TimeZone(identifier: "America/New_York")
+
+        var driftedStart = due
+        driftedStart.timeZone = nil
+        XCTAssertFalse(sameStoredDate(driftedStart, mirroredStart(from: due)))
+
+        let repaired = mirroredStart(from: due)
+        XCTAssertTrue(sameStoredDate(repaired, mirroredStart(from: due)))
+    }
+
+    func testSameStoredDateNilHandling() {
         var a = DateComponents()
         a.year = 2026; a.month = 9; a.day = 1
-        XCTAssertTrue(sameInstant(nil, nil))
-        XCTAssertFalse(sameInstant(a, nil))
-        XCTAssertFalse(sameInstant(nil, a))
+        XCTAssertTrue(sameStoredDate(nil, nil))
+        XCTAssertFalse(sameStoredDate(a, nil))
+        XCTAssertFalse(sameStoredDate(nil, a))
     }
 
     /// A repaired reminder must be a fixed point: repairing twice changes
@@ -95,8 +132,8 @@ final class StartDueSyncTests: XCTestCase {
         due.timeZone = TimeZone(identifier: "America/Los_Angeles")
 
         let once = mirroredStart(from: due)
-        XCTAssertTrue(sameInstant(once, mirroredStart(from: due)))
-        XCTAssertTrue(sameInstant(once, once))
+        XCTAssertTrue(sameStoredDate(once, mirroredStart(from: due)))
+        XCTAssertTrue(sameStoredDate(once, once))
     }
 }
 
@@ -159,6 +196,6 @@ final class AllDayDueDateTests: XCTestCase {
         XCTAssertNil(due.hour)
         XCTAssertEqual(start.hour, 0)
         XCTAssertEqual(start.minute, 0)
-        XCTAssertTrue(sameInstant(due, start))
+        XCTAssertTrue(sameStoredDate(due, start))
     }
 }

--- a/swift/Tests/ReminderCLITests/StartDueSyncTests.swift
+++ b/swift/Tests/ReminderCLITests/StartDueSyncTests.swift
@@ -99,3 +99,66 @@ final class StartDueSyncTests: XCTestCase {
         XCTAssertTrue(sameInstant(once, once))
     }
 }
+
+final class AllDayDueDateTests: XCTestCase {
+
+    // MARK: - isDateOnlyString
+
+    func testRecognizesISODateOnly() {
+        XCTAssertTrue(isDateOnlyString("2027-06-01"))
+        XCTAssertTrue(isDateOnlyString("2027-6-1"))
+        XCTAssertTrue(isDateOnlyString("  2027-06-01  "))
+    }
+
+    func testRecognizesSlashDateOnly() {
+        XCTAssertTrue(isDateOnlyString("06/01/2027"))
+        XCTAssertTrue(isDateOnlyString("6/1/2027"))
+    }
+
+    /// Regression: DateFormatter parses a *prefix*, so "2026-09-01 07:00"
+    /// satisfies a "yyyy-MM-dd" formatter. An anchored regex must not.
+    func testRejectsTimedStrings() {
+        XCTAssertFalse(isDateOnlyString("2026-09-01 07:00"))
+        XCTAssertFalse(isDateOnlyString("2026-09-01T07:00:00"))
+        XCTAssertFalse(isDateOnlyString("2026-09-01 9:30 AM"))
+        XCTAssertFalse(isDateOnlyString("09/01/2026 07:00"))
+    }
+
+    func testRejectsNonDates() {
+        XCTAssertFalse(isDateOnlyString(""))
+        XCTAssertFalse(isDateOnlyString("tomorrow"))
+        XCTAssertFalse(isDateOnlyString("next week"))
+    }
+
+    // MARK: - reminderDueComponents
+
+    func testDateOnlyStringOmitsTimeOfDay() throws {
+        let c = try XCTUnwrap(reminderDueComponents(from: "2027-06-01"))
+        XCTAssertEqual(c.year, 2027)
+        XCTAssertEqual(c.month, 6)
+        XCTAssertEqual(c.day, 1)
+        XCTAssertNil(c.hour, "an all-day reminder must carry no hour")
+        XCTAssertNil(c.minute, "an all-day reminder must carry no minute")
+    }
+
+    func testTimedStringKeepsTimeOfDay() throws {
+        let c = try XCTUnwrap(reminderDueComponents(from: "2026-09-03 09:30"))
+        XCTAssertEqual(c.hour, 9)
+        XCTAssertEqual(c.minute, 30)
+    }
+
+    func testUnparseableStringReturnsNil() {
+        XCTAssertNil(reminderDueComponents(from: "not a date at all"))
+    }
+
+    /// The all-day pair: due carries no time, start sits at midnight. This is
+    /// the shape Reminders.app itself writes.
+    func testAllDayPairMatchesRemindersAppShape() throws {
+        let due = try XCTUnwrap(reminderDueComponents(from: "2027-06-01"))
+        let start = mirroredStart(from: due)
+        XCTAssertNil(due.hour)
+        XCTAssertEqual(start.hour, 0)
+        XCTAssertEqual(start.minute, 0)
+        XCTAssertTrue(sameInstant(due, start))
+    }
+}

--- a/swift/Tests/ReminderCLITests/StartDueSyncTests.swift
+++ b/swift/Tests/ReminderCLITests/StartDueSyncTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import ReminderCLI
+
+final class StartDueSyncTests: XCTestCase {
+
+    // MARK: - mirroredStart
+
+    func testMirroredStartCopiesFullDateAndTime() {
+        var due = DateComponents()
+        due.year = 2026; due.month = 9; due.day = 3
+        due.hour = 9; due.minute = 30
+
+        let start = mirroredStart(from: due)
+        XCTAssertEqual(start.year, 2026)
+        XCTAssertEqual(start.month, 9)
+        XCTAssertEqual(start.day, 3)
+        XCTAssertEqual(start.hour, 9)
+        XCTAssertEqual(start.minute, 30)
+    }
+
+    /// Reminders.app stores an all-day reminder as a due date with no time
+    /// alongside a start date at midnight.
+    func testMirroredStartFillsMidnightForAllDayDueDate() {
+        var due = DateComponents()
+        due.year = 2026; due.month = 12; due.day = 1
+
+        let start = mirroredStart(from: due)
+        XCTAssertEqual(start.hour, 0)
+        XCTAssertEqual(start.minute, 0)
+        XCTAssertEqual(start.day, 1)
+    }
+
+    /// Regression: dropping the time zone made EventKit renormalize BOTH
+    /// fields into local time on save, silently rewriting the due date's
+    /// wall-clock representation.
+    func testMirroredStartPreservesTimeZone() {
+        var due = DateComponents()
+        due.year = 2026; due.month = 9; due.day = 3
+        due.hour = 9; due.minute = 30
+        due.timeZone = TimeZone(identifier: "America/New_York")
+
+        let start = mirroredStart(from: due)
+        XCTAssertEqual(start.timeZone, TimeZone(identifier: "America/New_York"))
+    }
+
+    func testMirroredStartKeepsNilTimeZoneNil() {
+        var due = DateComponents()
+        due.year = 2026; due.month = 9; due.day = 3
+        XCTAssertNil(mirroredStart(from: due).timeZone)
+    }
+
+    // MARK: - sameInstant
+
+    func testSameInstantTreatsMissingTimeAsMidnight() {
+        var dateOnly = DateComponents()
+        dateOnly.year = 2026; dateOnly.month = 12; dateOnly.day = 1
+
+        var midnight = dateOnly
+        midnight.hour = 0
+        midnight.minute = 0
+
+        XCTAssertTrue(sameInstant(dateOnly, midnight))
+    }
+
+    func testSameInstantDetectsDifferentDay() {
+        var a = DateComponents()
+        a.year = 2026; a.month = 8; a.day = 18
+        var b = a
+        b.day = 1
+        XCTAssertFalse(sameInstant(a, b))
+    }
+
+    func testSameInstantDetectsDifferentTime() {
+        var a = DateComponents()
+        a.year = 2026; a.month = 9; a.day = 1
+        a.hour = 7; a.minute = 0
+        var b = a
+        b.hour = 6
+        XCTAssertFalse(sameInstant(a, b))
+    }
+
+    func testSameInstantNilHandling() {
+        var a = DateComponents()
+        a.year = 2026; a.month = 9; a.day = 1
+        XCTAssertTrue(sameInstant(nil, nil))
+        XCTAssertFalse(sameInstant(a, nil))
+        XCTAssertFalse(sameInstant(nil, a))
+    }
+
+    /// A repaired reminder must be a fixed point: repairing twice changes
+    /// nothing the second time.
+    func testMirroredStartIsIdempotent() {
+        var due = DateComponents()
+        due.year = 2027; due.month = 6; due.day = 1
+        due.timeZone = TimeZone(identifier: "America/Los_Angeles")
+
+        let once = mirroredStart(from: due)
+        XCTAssertTrue(sameInstant(once, mirroredStart(from: due)))
+        XCTAssertTrue(sameInstant(once, once))
+    }
+}


### PR DESCRIPTION
## The bug

`reminder-cli` wrote `dueDateComponents` without touching `startDateComponents`. EventKit does not mirror the two for you, and Reminders.app writes both together on every save. So every update through this CLI left the old start date behind.

Two failure modes came out of that:

- **Stale start dates.** `Book Sarah Georgetown Pickup May 2027` carried `due 2026-10-01 09:00` against `start 2026-05-15 02:00`. One reminder had a start date in **2029** against a due date in 2027.
- **Dateless reminders.** Some ended up with a start date and a **nil** due date. Reminders.app renders those with no date at all, and third-party clients bucket them as due **today**. This is what surfaced the bug in the first place.

Across one real library: 37 reminders had drifted start dates and 2 were dateless.

## The fix

All three write sites (`create`, `update`, `batch-create`) now go through `setReminderDate`, so the pair cannot drift.

`mirroredStart` carries the due date's `timeZone` across. This part matters more than it looks: handing EventKit a start date with **no** time zone makes it renormalize *both* fields into local time on save, silently rewriting the due date's wall-clock representation. `2027-08-04 01:00` became `2027-08-03 18:00`, an exact UTC→PDT conversion. The firing instants were preserved, but four reminders lost their original time zone metadata before this was caught. There is a regression test for it.

`startDate` is gone from `reminderToDict` output. It mirrors `dueDate` by construction and Reminders.app exposes no separate control for it, so surfacing it only invites callers to treat it as meaningful.

## `repair-dates` — flagging this one for your judgement

New subcommand that repairs data already corrupted by the old behavior. Dry run unless `--apply`. It re-syncs drifted start dates and only **reports** start-only reminders, since picking a due date for those needs a human.

I included it because shipping the corruption fix without a repair path leaves every existing user's data broken with no way to find or fix it. But it is scope beyond the bug fix and adds a permanent public command. **Happy to drop it if you'd rather keep this release tight.**

## Testing

- 9 new regression tests in `swift/Tests/ReminderCLITests/StartDueSyncTests.swift`, covering time zone preservation, the all-day midnight shape, and idempotency
- 176 XCTest + 132 swift-testing pass
- 74 node tests pass
- Verified against a real library: after repair, `repair-dates` reports 0 drifted and 0 orphaned, and a full before/after diff confirms no due date moved

## Version

Bumped all five sources to **3.12.0**. Minor rather than patch because `repair-dates` is a new command. `scripts/check-versions.sh` passes.