### PR TITLE
fix: close #117 (EventKit surface audit, v3.15.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "apple-pim",
       "source": "./",
       "description": "Native macOS integration for Calendar, Reminders, Contacts, and Mail using EventKit, Contacts, and JXA frameworks",
-      "version": "3.14.0",
+      "version": "3.15.0",
       "keywords": [
         "calendar",
         "reminders",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "Native macOS integration for Calendar, Reminders, Contacts, and Mail using EventKit, Contacts, and JXA frameworks",
   "author": {
     "name": "Omar Shahine",

--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -77,5 +77,21 @@ jobs:
             --source-commit "${{ github.sha }}" \
             --source-ref "${{ github.ref_name }}"
 
-      - name: Verify
-        run: clawhub package inspect apple-pim-cli
+      # `clawhub package inspect apple-pim-cli` with no version prints whatever is
+      # currently latest and exits 0 either way, so it proved nothing about THIS
+      # publish — the same hole the NPM verify step had. Pinning `--version` makes
+      # it an assertion: the CLI exits 1 on "Version not found", so the loop ends
+      # only when the tag's version is actually resolvable.
+      - name: Verify the published version is live on ClawHub
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          for attempt in $(seq 1 20); do
+            if clawhub package inspect apple-pim-cli --version "$VERSION" --json > inspect.json; then
+              echo "apple-pim-cli@$VERSION is live on ClawHub."
+              exit 0
+            fi
+            echo "Attempt $attempt: $VERSION not on ClawHub yet; retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::apple-pim-cli@$VERSION never appeared on ClawHub after 5 minutes"
+          exit 1

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -51,5 +51,32 @@ jobs:
         run: npm publish --provenance --access public
         working-directory: openclaw
 
-      - name: Verify
-        run: npm view apple-pim-cli version
+      # npm answers `publish` before the version is queryable, and prints
+      # "Your package is being processed and may take a few minutes to become
+      # available" saying so. The previous check ran `npm view apple-pim-cli
+      # version` in the same job one line later and only ECHOED the result, so
+      # on the v3.14.0 run it printed 3.13.0 — the PREVIOUS version — and passed.
+      # A publish that genuinely failed to land looked identical.
+      #
+      # Poll the version-specific registry document instead, which 404s until the
+      # tag's version exists, and fail if it never appears. `no-cache` keeps a CDN
+      # copy of an earlier 404 from ending the poll early.
+      - name: Verify the published version is live on the registry
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          URL="https://registry.npmjs.org/apple-pim-cli/${VERSION}"
+          for attempt in $(seq 1 20); do
+            if curl -fsS -H 'Cache-Control: no-cache' "$URL" -o manifest.json; then
+              PUBLISHED=$(node -p "require('./manifest.json').version")
+              if [ "$PUBLISHED" = "$VERSION" ]; then
+                echo "apple-pim-cli@$VERSION is live on the registry."
+                exit 0
+              fi
+              echo "::error::Registry served version $PUBLISHED at $URL"
+              exit 1
+            fi
+            echo "Attempt $attempt: $VERSION not on the registry yet; retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::apple-pim-cli@$VERSION never appeared on the registry after 5 minutes"
+          exit 1

--- a/agents/pim-assistant.md
+++ b/agents/pim-assistant.md
@@ -238,6 +238,31 @@ When creating reminders:
   line — that mirrored line is the part the user actually sees and taps. Clearing the URL
   removes it; updating unrelated fields leaves both alone.
 - Use `reminder` with action `batch_create` when creating multiple reminders at once
+- **`alarm` moves the reminder — it is not an early heads-up.** Apple Reminders has one notion
+  of a reminder's time and shows the *earliest* alarm, falling back to the due date only when
+  there are no alarms. `alarm: [15]` on a reminder due at 3:00 makes it read and fire at 2:45,
+  with the 3:00 due time shown nowhere. There is no way to get "due 3:00, alert 2:45" to render
+  as a 3:00 reminder. If the user asks for an early warning, tell them that and offer either a
+  due date at the earlier time or a second reminder. Use `alarm: [0]` to alert at the due date.
+  The tool returns a `warnings` array whenever a write moves the visible time — pass it on
+  rather than reporting plain success
+
+### What you cannot do
+
+These are Reminders/Calendar features with **no EventKit API**. When asked for one, say it is
+not possible through this tool and stop. Do not improvise something adjacent — a `#tag` written
+into a title, five flat reminders standing in for a checklist, or "SUBTASK:" in the notes all
+create data the user did not ask for and has to undo by hand.
+
+- **Subtasks / nesting** — verified dead. The relationship can only be made in the Reminders UI
+- **Tags** — a `#tag` in a title or note is inert text, not a tag
+- **Flag** — no API. This is distinct from priority, which *is* supported
+- **Attached images or files** — no API. Offer a URL instead
+- **Sections within a list**, **Smart Lists**, **Remind me when messaging**, **assignee on a
+  shared list** — no API
+
+Calendar event `url` is *not* one of these: Calendar renders it as a live link in the event
+inspector, so a URL on an event reaches the user as-is.
 
 ### Completing Reminders
 - For a single reminder: use `reminder` with action `complete`

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -179,7 +179,7 @@ export const tools = [
             "to store the URL for machine use only, accepting that nothing about it is visible " +
             "in Apple Reminders. Ignored when no url is supplied.",
         },
-        alarm: { type: "array", items: { type: "number" }, description: "Alarm minutes before due" },
+        alarm: { type: "array", items: { type: "number" }, description: "Alarm minutes before due. NOT an early heads-up: Apple Reminders shows a reminder at its earliest alarm, so 15 on a reminder due at 3:00 makes it read and fire at 2:45, with the due time shown nowhere. Use 0 to alert at the due date." },
         // No `required` here — empty object {} means "remove location" (batch_create has required since it doesn't support removal)
         location: {
           type: "object",
@@ -217,7 +217,12 @@ export const tools = [
                 type: "boolean",
                 description: "Mirror url into the notes as a visible link (default true).",
               },
-              alarm: { type: "array", items: { type: "number" } },
+              alarm: {
+                type: "array",
+                items: { type: "number" },
+                description:
+                  "Alarm minutes before due. Reminders shows a reminder at its earliest alarm, so a nonzero value moves the time the reminder displays and fires. Use 0 to alert at the due date.",
+              },
               location: {
                 type: "object",
                 properties: {

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -77126,7 +77126,7 @@ import { dirname as dirname2, join as join3 } from "path";
 // package.json
 var package_default = {
   name: "apple-pim-mcp",
-  version: "3.14.0",
+  version: "3.15.0",
   description: "MCP server for Apple PIM, a Personal Information Manager for Calendar, Reminders, Contacts, and Mail",
   type: "module",
   main: "dist/server.js",
@@ -77847,7 +77847,7 @@ var tools = [
           type: "boolean",
           description: "Whether to mirror `url` into the notes as a visible link (default true). Set false to store the URL for machine use only, accepting that nothing about it is visible in Apple Reminders. Ignored when no url is supplied."
         },
-        alarm: { type: "array", items: { type: "number" }, description: "Alarm minutes before due" },
+        alarm: { type: "array", items: { type: "number" }, description: "Alarm minutes before due. NOT an early heads-up: Apple Reminders shows a reminder at its earliest alarm, so 15 on a reminder due at 3:00 makes it read and fire at 2:45, with the due time shown nowhere. Use 0 to alert at the due date." },
         // No `required` here — empty object {} means "remove location" (batch_create has required since it doesn't support removal)
         location: {
           type: "object",
@@ -77883,7 +77883,11 @@ var tools = [
                 type: "boolean",
                 description: "Mirror url into the notes as a visible link (default true)."
               },
-              alarm: { type: "array", items: { type: "number" } },
+              alarm: {
+                type: "array",
+                items: { type: "number" },
+                description: "Alarm minutes before due. Reminders shows a reminder at its earliest alarm, so a nonzero value moves the time the reminder displays and fires. Use 0 to alert at the due date."
+              },
               location: {
                 type: "object",
                 properties: {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim-mcp",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "MCP server for Apple PIM, a Personal Information Manager for Calendar, Reminders, Contacts, and Mail",
   "type": "module",
   "main": "dist/server.js",

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -92,7 +92,7 @@
       }
     }
   },
-  "version": "3.14.0",
+  "version": "3.15.0",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim-cli",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "OpenClaw plugin for macOS Calendar, Reminders, Contacts, and Mail. macOS-only; depends on four native Swift CLIs (calendar-cli, reminder-cli, contacts-cli, mail-cli) you build locally from source via ./setup.sh. The registry does not download or install binaries.",
   "type": "module",
   "scripts": {

--- a/skills/apple-pim/SKILL.md
+++ b/skills/apple-pim/SKILL.md
@@ -200,6 +200,41 @@ When reading events/reminders, the `recurrence` array includes:
    that line; updating other fields preserves both. Pass `urlInNotes: false` (or
    `--no-url-in-notes` on the CLI) when you want the value stored for machine use only
 
+8. **`alarm` on a reminder moves the reminder; it is not an early heads-up** — Apple Reminders
+   has one notion of a reminder's time and draws the *earliest* alarm, falling back to the due
+   date only when a reminder has no alarms. `alarm: [15]` on a reminder due at 3:00 makes it
+   read and fire at 2:45, and the 3:00 due time appears nowhere in the app. Adding a companion
+   alarm at the due date does not restore it (earliest still wins), and an absolute alarm
+   resolves to the same instant. Use `alarm: [0]` to alert at the due date — that is what
+   Reminders itself writes — or set the due date to the time the user actually wants. The CLI
+   returns a `warnings` array whenever a write moves the visible time; surface it
+9. **`startDate` mirrors the due date and is returned on reads** — Reminders offers no separate
+   start-date control, so the CLI keeps the two in sync on every write. A reminder that ends up
+   with a start date but no due date renders as *dateless* in Reminders while still occupying a
+   date slot in EventKit; the returned `startDate` is how you diagnose that
+
+### What EventKit cannot reach
+
+These are Reminders/Calendar features with no EventKit API. **Say so and stop — do not
+improvise an adjacent thing.** Writing `#tag` into a title, creating five flat reminders to
+stand in for a checklist, or putting "SUBTASK:" in the notes produces data the user did not ask
+for and has to clean up by hand.
+
+| Feature | Status |
+| --- | --- |
+| Subtasks / nesting | **Verified dead.** `parentID` (type `EKObjectID`) accepts a `setValue` in memory but does not survive `eventStore.save()`; every object ID comes back temporary, and AppleScript's `container` is read-only. Only the Reminders UI can create the relationship |
+| Tags | No API — a `#tag` in a title or note is inert text, not a tag |
+| Flag | No API. Distinct from priority, which *is* supported |
+| Attached images / files | No API. Part of why a link has to live in `notes` to be reachable |
+| Sections within a list | No API |
+| Smart Lists | No API |
+| Remind me when messaging | No API |
+| Assignee on a shared list | No API |
+
+Calendar's `url` field is **not** on this list: Calendar renders `EKEvent.url` as a live link in
+the event inspector, so `url` on an event reaches the user as-is and needs no mirroring. Only
+Reminders hides it.
+
 ### Contact Management
 1. **Use unified contacts** for consistent view across accounts
 2. **Preserve existing data** when updating (only modify changed fields)

--- a/swift/Sources/MailCLI/MessageLocator.swift
+++ b/swift/Sources/MailCLI/MessageLocator.swift
@@ -75,6 +75,17 @@ struct NoopLocator: MessageLocator {
 /// - `jxa`: no locator, no database opened.
 /// - `auto`: locator when one can be opened, silently Noop otherwise.
 /// - `sqlite`: locator required; an open failure is reported to the caller.
+///
+/// KNOWN GAP, and the reason it is stated here rather than left to be rediscovered: the
+/// account-ambiguity refusal `SQLiteEngine.resolve` raises needs the Envelope Index to see
+/// that a name spans two logical accounts, so the `.jxa` arm above — which opens no database
+/// by contract — cannot raise it, and an ambiguous hint falls through to the JXA scan's
+/// first-match resolution. This is NOT the read/write split: every read command guards its
+/// fast path with the same `engine != .jxa`, so `--engine jxa` skips the check for reads
+/// exactly as it does for writes. Closing it means either opening the index under `--engine
+/// jxa` (breaking the contract, and unavailable anyway without Full Disk Access) or teaching
+/// the JXA sites to treat a multi-result `Mail.accounts.whose({name:})` as ambiguous.
+/// Tracked separately rather than changed here.
 func makeMessageLocator(engine: EngineChoice) throws -> MessageLocator {
     guard engine != .jxa else { return NoopLocator() }
     do {

--- a/swift/Sources/MailCLI/SQLiteEngine.swift
+++ b/swift/Sources/MailCLI/SQLiteEngine.swift
@@ -366,13 +366,22 @@ extension SQLiteEngine: MessageLocator {
         // accelerates here and matches no account there — the same command completes under
         // `--engine auto` and reports "Message not found" under `--engine jxa`.
         //
-        // `try?` swallows `.ambiguous` on purpose — fail OPEN: an empty UUID set skips the byId
-        // path and lets JXA pick exactly as it would with no locator. Correct but slow, never
-        // wrong. Pinned by
-        // `MessageLocatorTests.testAnAMBIGUOUSAccountHintFailsOPENToEmptyCandidates`.
+        // `.ambiguous` PROPAGATES rather than being swallowed. Failing open here is correct
+        // about the locator in isolation — an empty UUID set skips the byId path and leaves
+        // JXA to pick exactly as it would with no locator — but it is wrong about the net
+        // effect, because the path it opens into is the JXA mailbox scan, which resolves
+        // accounts by FIRST MATCH. That is the same silent wrong-account pick the read path
+        // refuses outright (`rethrowFatalFastPathError`), so failing open here made an
+        // ambiguous account scope refuse a READ and guess a WRITE — backwards, since the
+        // write is the more consequential of the two.
+        //
+        // `resolveRowidMap` routes this through `rethrowFatalFastPathError`, which turns
+        // `.ambiguous` into `CLIError.invalidInput` under EVERY engine. Other errors out of
+        // the accounts store still fail open there, so a genuine index failure degrades to
+        // the scan as before — only the caller's own ambiguous input is refused.
         var accountUUIDs: Set<String>?
         if let account {
-            accountUUIDs = Set((try? index.accountUUIDs(matching: account)) ?? [])
+            accountUUIDs = Set(try index.accountUUIDs(matching: account))
         }
 
         // Every requested id is a key, so the JXA side can tell "resolved to nothing" from

--- a/swift/Sources/ReminderCLI/ReminderCLI.swift
+++ b/swift/Sources/ReminderCLI/ReminderCLI.swift
@@ -191,6 +191,13 @@ func reminderToDict(_ reminder: EKReminder) -> [String: Any] {
     if let dueDate = reminder.dueDateComponents {
         dict["dueDate"] = dateComponentsToString(dueDate)
     }
+    if let startDate = reminder.startDateComponents {
+        // Written on every dated reminder, mirrored from the due date (`setReminderDueDate`).
+        // Returned so that mirroring is inspectable rather than implicit: a reminder carrying a
+        // start date but no due date renders as dateless in Reminders.app, and that is only
+        // diagnosable if reads show the field.
+        dict["startDate"] = dateComponentsToString(startDate)
+    }
     if let notes = reminder.notes, !notes.isEmpty {
         dict["notes"] = notes
     }
@@ -207,6 +214,51 @@ func reminderToDict(_ reminder: EKReminder) -> [String: Any] {
     }
 
     return dict
+}
+
+/// When a reminder's earliest alarm lands before its due date, the alert moment and the due
+/// moment — in that order.
+///
+/// Reminders.app has ONE notion of a reminder's time: it draws the EARLIEST alarm, and falls
+/// back to the due date only when a reminder has no alarms at all. So an alarm 15 minutes
+/// before a 3:00 due date does not add a heads-up ahead of a 3:00 reminder — it makes the
+/// reminder read 2:45, and the due time appears nowhere in the app.
+///
+/// Verified against Reminders.app on macOS 26: due 15:00 with no alarm renders "3:00 PM"; the
+/// same reminder with a -15m alarm renders "2:45 PM"; adding a companion offset-0 alarm does
+/// NOT restore it, because earliest still wins. Converting the offset to an absolute alarm
+/// resolves to the same instant and renders identically. Reminders' own writes only ever use
+/// `relativeOffset: 0` — an alert AT the due date — which is why the app has no UI for this
+/// and no way to draw it.
+///
+/// There is therefore no EventKit shape that renders as "due 3:00, alert 2:45". The field is
+/// not invisible, which mirroring could fix; it is *load-bearing in a way the caller did not
+/// ask for*, so the only honest move left is to say so at the moment it is written.
+///
+/// Location alarms carry no time of their own and are excluded.
+func earlyAlarmShift(for reminder: EKReminder) -> (alert: Date, due: Date)? {
+    guard let dueComponents = reminder.dueDateComponents,
+          let due = Calendar.current.date(from: dueComponents),
+          let alarms = reminder.alarms else { return nil }
+    let alertDates = alarms.compactMap { alarm -> Date? in
+        guard alarm.structuredLocation == nil else { return nil }
+        return alarm.absoluteDate ?? due.addingTimeInterval(alarm.relativeOffset)
+    }
+    guard let earliest = alertDates.min(), earliest < due else { return nil }
+    return (earliest, due)
+}
+
+/// The caller-facing form of `earlyAlarmShift`, or `nil` when nothing is being moved.
+func earlyAlarmWarnings(for reminder: EKReminder) -> [String] {
+    guard let shift = earlyAlarmShift(for: reminder) else { return [] }
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd HH:mm"
+    return ["Apple Reminders shows a reminder at its earliest alarm, not its due date, so this "
+            + "reminder will display and fire at \(formatter.string(from: shift.alert)) rather "
+            + "than \(formatter.string(from: shift.due)). Reminders has one alert per reminder "
+            + "and no separate due time, so an early alert cannot be added alongside the due "
+            + "date. Use an alarm of 0 to alert at the due date, or set the due date to when "
+            + "you actually want to be reminded."]
 }
 
 /// Marker line that carries a reminder's URL where Apple Reminders will actually show it.
@@ -264,8 +316,7 @@ func dateComponentsToString(_ components: DateComponents) -> String {
     return dateStr
 }
 
-/// Sets a reminder's date, keeping `startDateComponents` mirrored to
-/// `dueDateComponents`.
+/// Sets a reminder's due date and mirrors `startDateComponents` to match.
 ///
 /// Reminders.app writes both fields together and offers no separate "start
 /// date" control, but EventKit does not mirror them for you. Writing due
@@ -273,14 +324,6 @@ func dateComponentsToString(_ components: DateComponents) -> String {
 /// ends up with a start date but no due date renders as *dateless* in
 /// Reminders.app while still occupying a date slot in EventKit. Always go
 /// through this instead of assigning `dueDateComponents` directly.
-/// Sets a reminder's due date and mirrors `startDateComponents` to match.
-///
-/// Reminders.app writes both fields together and offers no separate "start
-/// date" control, but EventKit does not mirror them for you. Writing due
-/// alone leaves whatever start date was there before, and a reminder that
-/// ends up with a start date but no due date renders as *dateless* in
-/// Reminders.app. Always go through this instead of assigning
-/// `dueDateComponents` directly.
 func setReminderDueDate(_ reminder: EKReminder, to due: DateComponents?) {
     reminder.dueDateComponents = due
     reminder.startDateComponents = due.map { mirroredStart(from: $0) }
@@ -345,6 +388,12 @@ func alarmToDict(_ alarm: EKAlarm) -> [String: Any] {
     var dict: [String: Any] = [
         "relativeOffset": alarm.relativeOffset
     ]
+
+    if let absoluteDate = alarm.absoluteDate {
+        // An absolute alarm reports `relativeOffset: 0`, so without this an alarm pinned to a
+        // fixed moment read back identically to one anchored on the due date.
+        dict["absoluteDate"] = ISO8601DateFormatter().string(from: absoluteDate)
+    }
 
     if let location = alarm.structuredLocation {
         var locDict: [String: Any] = [:]
@@ -808,7 +857,11 @@ struct CreateReminder: AsyncParsableCommand {
           help: "Mirror --url into the notes so Apple Reminders shows a tappable link")
     var urlInNotes: Bool = true
 
-    @Option(name: .long, help: "Alarm minutes before due (can specify multiple)")
+    @Option(name: .long, help: ArgumentHelp(
+        "Alarm minutes before due (can specify multiple). NOT an early heads-up: Apple "
+        + "Reminders shows a reminder at its earliest alarm, so --alarm 15 on a reminder due "
+        + "at 3:00 makes it read and fire at 2:45, with the due time shown nowhere. Use 0 to "
+        + "alert at the due date, which is what Reminders itself writes"))
     var alarm: [Int] = []
 
     @Option(name: .long, help: "Recurrence rule as JSON (e.g., '{\"frequency\":\"monthly\",\"interval\":1}')")
@@ -862,11 +915,17 @@ struct CreateReminder: AsyncParsableCommand {
 
         try eventStore.save(reminder, commit: true)
 
-        outputJSON([
+        var payload: [String: Any] = [
             "success": true,
             "message": "Reminder created successfully",
             "reminder": reminderToDict(reminder)
-        ])
+        ]
+        // Loud at the moment it happens: an early alarm silently relocates the reminder in
+        // Reminders.app, and nothing downstream can tell that from a reminder genuinely due
+        // then. See `earlyAlarmShift`.
+        let warnings = earlyAlarmWarnings(for: reminder)
+        if !warnings.isEmpty { payload["warnings"] = warnings }
+        outputJSON(payload)
     }
 }
 
@@ -1027,11 +1086,16 @@ struct UpdateReminder: AsyncParsableCommand {
 
         try eventStore.save(reminder, commit: true)
 
-        outputJSON([
+        var payload: [String: Any] = [
             "success": true,
             "message": "Reminder updated successfully",
             "reminder": reminderToDict(reminder)
-        ])
+        ]
+        // Reachable without touching alarms at all: moving the due date LATER can push an
+        // existing alarm before it, so the check is on the saved state, not on what changed.
+        let warnings = earlyAlarmWarnings(for: reminder)
+        if !warnings.isEmpty { payload["warnings"] = warnings }
+        outputJSON(payload)
     }
 }
 
@@ -1122,6 +1186,7 @@ struct BatchCreateReminder: AsyncParsableCommand {
 
         var createdReminders: [[String: Any]] = []
         var errors: [[String: Any]] = []
+        var warnings: [String] = []
 
         for (index, reminderInput) in reminders.enumerated() {
             do {
@@ -1174,6 +1239,9 @@ struct BatchCreateReminder: AsyncParsableCommand {
                 // Save with commit: false to batch changes
                 try eventStore.save(reminder, commit: false)
                 createdReminders.append(reminderToDict(reminder))
+                warnings.append(contentsOf: earlyAlarmWarnings(for: reminder).map {
+                    "\(reminderInput.title): \($0)"
+                })
             } catch {
                 errors.append([
                     "index": index,
@@ -1188,14 +1256,16 @@ struct BatchCreateReminder: AsyncParsableCommand {
             try eventStore.commit()
         }
 
-        outputJSON([
+        var payload: [String: Any] = [
             "success": errors.isEmpty,
             "message": "Batch create completed",
             "created": createdReminders,
             "createdCount": createdReminders.count,
             "errors": errors,
             "errorCount": errors.count
-        ])
+        ]
+        if !warnings.isEmpty { payload["warnings"] = warnings }
+        outputJSON(payload)
     }
 }
 

--- a/swift/Tests/MailCLITests/MessageLocatorTests.swift
+++ b/swift/Tests/MailCLITests/MessageLocatorTests.swift
@@ -190,17 +190,18 @@ final class MessageLocatorTests: XCTestCase {
         XCTAssertEqual(refs["gmail-only@example.com"]?.isEmpty, true)
     }
 
-    func testAnAMBIGUOUSAccountHintFailsOPENToEmptyCandidates() throws {
+    func testAnAMBIGUOUSAccountHintREFUSESTheWrite() throws {
         // The other account-hint failure: `accountUUIDs(matching:)` THROWS `.ambiguous` for a
-        // name spanning two logical accounts. A write must not inherit that (JXA still
-        // completes the write under `--engine auto`), so `resolve`'s `try?` fails OPEN. Every
-        // other fixture leaves the throw unreachable; this one reaches it.
+        // name spanning two logical accounts. `resolve` used to swallow that with `try?` and
+        // fail OPEN, which is correct about the LOCATOR and wrong about the net effect — the
+        // path it opened into is the JXA mailbox scan, which resolves accounts by first match.
+        // An ambiguous scope therefore refused a read and GUESSED a write. It now propagates,
+        // and `rethrowFatalFastPathError` turns it into a caller error under every engine.
         let index = try openFixture(accountsSQL: Self.sharedUsernameAccountRows)
 
         // Precondition: the throw actually fires here. Without it this test's outcome is
         // indistinguishable from `testUnresolvableAccountYieldsEmptyCandidatesAndDoesNotThrow`
-        // above — an account that merely matched nothing — and the swallow would still be
-        // untested.
+        // above — an account that merely matched nothing.
         XCTAssertThrowsError(try index.accountUUIDs(matching: "shared@example.com")) { error in
             guard case EnvelopeIndexError.ambiguous(let message) = error else {
                 return XCTFail("fixture precondition: expected .ambiguous, got \(error)")
@@ -211,37 +212,46 @@ final class MessageLocatorTests: XCTestCase {
         let engine = try SQLiteEngine(index: index)
 
         // Control, same database, same seam: an UNAMBIGUOUS hint still resolves. This is what
-        // separates "the swallow fired" from "the accounts store never loaded" — an unwired
+        // separates "the refusal fired" from "the accounts store never loaded" — an unwired
         // seam would empty this arm too.
         let unambiguous = try engine.resolve(
             messageIds: ["<gmail-only@example.com>"], mailbox: nil, account: "Shared A")
         XCTAssertEqual(unambiguous["gmail-only@example.com"]?.count, 1)
         XCTAssertEqual(unambiguous["gmail-only@example.com"]?.first?.accountUUID, gmailAccount)
 
-        // The fail-open. A throw out of `resolve` fails this test outright (it propagates);
-        // what is asserted is the shape the comment promises — every requested id still a key,
-        // every one carrying an empty candidate list, including ids in BOTH of the accounts the
-        // ambiguous username spans.
-        let refs = try engine.resolve(
+        // The refusal, carrying the ambiguity out of `resolve` unchanged so the caller is told
+        // which hint was ambiguous rather than being handed a first-match guess.
+        XCTAssertThrowsError(try engine.resolve(
             messageIds: ["<gmail-only@example.com>", "<other-acct@example.com>",
                          "<nope@example.com>"],
-            mailbox: nil, account: "shared@example.com")
+            mailbox: nil, account: "shared@example.com")) { error in
+            guard case EnvelopeIndexError.ambiguous(let message) = error else {
+                return XCTFail("expected .ambiguous out of resolve, got \(error)")
+            }
+            XCTAssertTrue(message.contains("multiple logical accounts"))
+        }
+    }
 
-        XCTAssertEqual(Set(refs.keys),
-                       ["gmail-only@example.com", "other-acct@example.com", "nope@example.com"])
-        for (id, candidates) in refs {
-            XCTAssertTrue(candidates.isEmpty, "\(id) must resolve to no candidates")
+    func testAmbiguousAccountIsFatalUnderEveryEngine() throws {
+        // The read path makes `.ambiguous` fatal regardless of engine because it describes the
+        // caller's INPUT, not the engine. The write path reaches the same helper through
+        // `resolveRowidMap`'s catch, so this holds the shared contract: `auto` must not
+        // degrade an ambiguous hint into the guessing scan the way it degrades a real engine
+        // failure.
+        let ambiguous = EnvelopeIndexError.ambiguous("Account matches multiple logical accounts: x")
+        for engine in [EngineChoice.auto, .sqlite, .jxa] {
+            XCTAssertThrowsError(try rethrowFatalFastPathError(engine, ambiguous)) { error in
+                guard case CLIError.invalidInput = error else {
+                    return XCTFail("\(engine): expected invalidInput, got \(error)")
+                }
+            }
         }
 
-        // And the same thing as JXA sees it: the comment's claim is about `lookup.candidates`,
-        // which the JS side reads off this map. Every array empty is `candidates.length === 0`
-        // for every id, so the `whose` scan makes every selection — v3.11's behaviour exactly.
-        let map = try parseRowidMap(buildRowidMapJS(refs))
-        XCTAssertEqual(Set(map.keys),
-                       ["gmail-only@example.com", "other-acct@example.com", "nope@example.com"])
-        for (id, entries) in map {
-            XCTAssertTrue(entries.isEmpty, "\(id) must reach JXA with an empty candidate array")
-        }
+        // The contrast that makes the line above mean something: a NON-ambiguity failure still
+        // fails open under `auto`, so a missing or unreadable index degrades to the JXA scan
+        // exactly as before. Only the caller's own ambiguous input is refused.
+        XCTAssertNoThrow(try rethrowFatalFastPathError(.auto, CLIError.notFound("no index")))
+        XCTAssertThrowsError(try rethrowFatalFastPathError(.sqlite, CLIError.notFound("no index")))
     }
 
     // MARK: - Candidate ordering

--- a/swift/Tests/ReminderCLITests/EarlyAlarmWarningTests.swift
+++ b/swift/Tests/ReminderCLITests/EarlyAlarmWarningTests.swift
@@ -1,0 +1,80 @@
+import EventKit
+import XCTest
+@testable import ReminderCLI
+
+/// Reminders.app draws a reminder at its EARLIEST alarm and falls back to the due date only
+/// when there are no alarms, so a nonzero `--alarm` relocates the reminder instead of adding a
+/// heads-up before it. `earlyAlarmShift` is what makes that loud; these hold its edges.
+///
+/// Observed on macOS 26 with three reminders all due 2026-08-26 15:00: no alarm renders
+/// "3:00 PM", a -15m alarm renders "2:45 PM", and offset-0 PLUS -15m still renders "2:45 PM".
+final class EarlyAlarmWarningTests: XCTestCase {
+
+    private let store = EKEventStore()
+
+    private func makeReminder(dueHour: Int?, offsets: [TimeInterval]) -> EKReminder {
+        let reminder = EKReminder(eventStore: store)
+        if let dueHour {
+            var due = DateComponents()
+            due.year = 2026; due.month = 8; due.day = 26
+            due.hour = dueHour; due.minute = 0
+            reminder.dueDateComponents = due
+        }
+        for offset in offsets { reminder.addAlarm(EKAlarm(relativeOffset: offset)) }
+        return reminder
+    }
+
+    func testAnAlarmBeforeTheDueDateReportsTheShift() {
+        let reminder = makeReminder(dueHour: 15, offsets: [-900])
+
+        guard let shift = earlyAlarmShift(for: reminder) else {
+            return XCTFail("a -15m alarm moves the displayed time and must be reported")
+        }
+        XCTAssertEqual(shift.due.timeIntervalSince(shift.alert), 900)
+        XCTAssertEqual(earlyAlarmWarnings(for: reminder).count, 1)
+        XCTAssertTrue(earlyAlarmWarnings(for: reminder)[0].contains("14:45"))
+    }
+
+    /// The alarm Reminders itself writes for every timed reminder. It lands exactly ON the due
+    /// date, so nothing moves and warning about it would be noise on the common path.
+    func testAnAlarmAtTheDueDateIsNotAShift() {
+        XCTAssertNil(earlyAlarmShift(for: makeReminder(dueHour: 15, offsets: [0])))
+        XCTAssertTrue(earlyAlarmWarnings(for: makeReminder(dueHour: 15, offsets: [0])).isEmpty)
+    }
+
+    /// The case that rules out "add a companion alarm at the due date" as a fix: Reminders
+    /// takes the EARLIEST, so the offset-0 alarm does not restore the 3:00 PM label. The helper
+    /// has to agree, or it would go quiet on precisely the shape that still renders wrong.
+    func testEarliestAlarmWinsOverACompanionAtTheDueDate() {
+        guard let shift = earlyAlarmShift(for: makeReminder(dueHour: 15, offsets: [0, -900])) else {
+            return XCTFail("earliest alarm still moves the displayed time")
+        }
+        XCTAssertEqual(shift.due.timeIntervalSince(shift.alert), 900)
+    }
+
+    /// An alarm AFTER the due date does not move the label — Reminders takes the earliest, and
+    /// the due date is earlier. Only shifts that make the reminder read early are reported.
+    func testAnAlarmAfterTheDueDateIsNotReported() {
+        XCTAssertNil(earlyAlarmShift(for: makeReminder(dueHour: 15, offsets: [900])))
+    }
+
+    func testNoAlarmsAndNoDueDateAreBothSilent() {
+        XCTAssertNil(earlyAlarmShift(for: makeReminder(dueHour: 15, offsets: [])))
+        XCTAssertNil(earlyAlarmShift(for: makeReminder(dueHour: nil, offsets: [-900])))
+    }
+
+    /// A location alarm carries no time of its own — `relativeOffset` is 0 and meaningless —
+    /// so counting it would fire the warning on a geofenced reminder that displays fine.
+    func testLocationAlarmsAreExcluded() {
+        let reminder = makeReminder(dueHour: 15, offsets: [])
+        let alarm = EKAlarm()
+        let location = EKStructuredLocation(title: "Home")
+        location.radius = 100
+        alarm.structuredLocation = location
+        alarm.proximity = .enter
+        alarm.relativeOffset = -3600
+        reminder.addAlarm(alarm)
+
+        XCTAssertNil(earlyAlarmShift(for: reminder))
+    }
+}


### PR DESCRIPTION
Closes #117.

Settles the audit's two open assessments by looking at the apps, then fixes what the answers implied. Items 1 and 2 were flagged as "assessments from source, not observations of the apps" — both were checked against Reminders.app and Calendar.app on macOS 26 via accessibility reads.

## 1. `EKEvent.url` renders — not #113 on the calendar side

Calendar.app's event inspector draws it as a live link:

```
207 text field (settable), Value: https://example.com/pim-url-probe, Placeholder: Add URL
    208 link https://example.com/pim-url-probe
```

No mirroring added. Only Reminders hides `url`. Written into the docs so it stops being re-litigated.

## 2. Relative alarms on reminders are worse than invisible

Reminders.app shows a reminder at its **earliest alarm**, and falls back to the due date only when there are no alarms. Three reminders all due `2026-08-26 15:00`:

| Alarms | Reminders.app shows |
| --- | --- |
| none | **3:00 PM** |
| `-15m` | **2:45 PM** |
| `0` + `-15m` | **2:45 PM** |

So `--alarm 15` does not add a heads-up before a 3:00 reminder — it makes the reminder read 2:45, and the due time appears nowhere.

Both candidate fixes were ruled out against the app, not from source. A companion offset-0 alarm does not restore the label (earliest still wins, row 3), and the issue's suggested "convert the offset to an absolute alert" resolves to the same instant and renders identically. Reminders' own writes only ever use `relativeOffset: 0` — every timed reminder in the live database created by the app has it — which is why there is no UI for an early alert and no way to draw one.

Since no EventKit shape renders as "due 3:00, alert 2:45", the write says so instead:

```json
{
  "success": true,
  "reminder": { "dueDate": "2026-08-26 15:00", "startDate": "2026-08-26 15:00", "alarms": [{"relativeOffset": -900}] },
  "warnings": ["Apple Reminders shows a reminder at its earliest alarm, not its due date, so this reminder will display and fire at 2026-08-26 14:45 rather than 2026-08-26 15:00. …"]
}
```

`--alarm 0` stays silent — nothing moves, and warning on the common path would be noise. Help text and MCP schema descriptions no longer imply an early heads-up. `alarms[].absoluteDate` is now reported too; it was being dropped, so an alarm pinned to a fixed moment read back identically to one anchored on the due date.

## 3. `startDate` is returned from reminder reads

The only write-without-read asymmetry in either CLI, which made the #111 mirroring impossible to inspect. Also collapsed a duplicated doc comment on `setReminderDueDate` left over from that PR.

## 4. An ambiguous account now refuses a write, not just a read

`SQLiteEngine.resolve` swallowed `.ambiguous` with `try?`. That reasoning is right about the *locator* and wrong about the net effect: the path it opens into is the JXA mailbox scan, which resolves accounts by first match. An ambiguous scope refused a read and guessed a write — backwards, since the write is the more consequential.

`resolveRowidMap` already routes errors through `rethrowFatalFastPathError`, which turns `.ambiguous` into `CLIError.invalidInput` under every engine, so propagating was enough. Non-ambiguity failures still fail open to the scan, so a missing or unreadable index degrades exactly as before — only the caller's own ambiguous input is refused.

`testAnAMBIGUOUSAccountHintFailsOPENToEmptyCandidates` is flipped to `testAnAMBIGUOUSAccountHintREFUSESTheWrite`, plus a new test holding the shared read/write contract across all three engine choices.

## 5. The unreachable set is in agent guidance

Subtasks, tags, flag, attachments, sections, Smart Lists, messaging triggers, shared-list assignees — in `SKILL.md` and `pim-assistant.md`, with an explicit instruction to decline rather than improvise a `#tag` in a title or five flat reminders standing in for a checklist. Both note that Calendar's `url` is *not* on the list.

## Publish workflows now verify something

`npm view` ran in the same job as `npm publish` and only echoed its output, so on the v3.14.0 run it printed `3.13.0` and passed. NPM now polls the version-specific registry document (404s until the version is live; `no-cache` so a CDN copy of an earlier 404 can't end the poll early). ClawHub uses `inspect --version <V> --json`, which exits 1 on "Version not found". Both bounded at 20 × 15s.

## Testing

- `swift test`: 291 XCTest + 132 swift-testing, 0 failures
- `mcp-server`: 83 passed
- `npm run eval`: 148 passed (5 files)
- Probe reminders and the probe calendar event were created against live data and deleted afterward; nothing left behind.

## Not settled

**Is a reminder with no alarm actually mute?** Reminders.app writes `relativeOffset: 0` on every timed reminder it creates; ours write no alarm at all. Two probes due two minutes out produced no notification — but it was 04:14 with Focus almost certainly on, and the `--alarm 0` control was equally silent, so the test proves nothing either way. If alarm-less reminders don't fire, that is a larger #113 than anything in this audit and deserves its own issue. Left unclaimed rather than guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)