### PR TITLE
fix(doctor): probe the PIMHelper route, not only the direct one

### DIFF
--- a/commands/authorize.md
+++ b/commands/authorize.md
@@ -67,15 +67,19 @@ binds to the helper's bundle + signature, and it persists across host apps.
 Consequences to explain to the user:
 
 - **`notDetermined` is normal and permanent on the direct probe.** The grant
-  lives on the helper, invisible to `auth-status`. If actual Calendar /
-  Reminders / Contacts calls succeed, authorization is fine — do NOT chase
-  the `notDetermined` reading or tell the user to grant the terminal.
+  lives on the helper, where a direct `auth-status` cannot see it. If actual
+  Calendar / Reminders / Contacts calls succeed, authorization is fine — do
+  NOT chase the `notDetermined` reading or tell the user to grant the
+  terminal. To read the helper's own status, run `scripts/doctor.sh`: it
+  probes both routes and prints a line per route per domain.
 - **The first helper call per domain raises the macOS dialog.** The runner
   allows ~2 minutes for it; tell the user to watch for and answer the
   prompt. Grants persist afterward.
 - **Re-signing the helper drops all its grants.** `scripts/build-helper-app.sh`
   therefore skips rebuilding when nothing changed; expect re-prompts only
-  after a real helper update.
+  after a real helper update. When it has happened, `scripts/doctor.sh`
+  reports the helper route as not granted while the direct probe still reads
+  the same as before.
 - **If helper calls fail with Launch Services error -1712**, a previous
   helper instance is stuck (typically an unanswered dialog). Run
   `scripts/doctor.sh --fix` (see `/apple-pim:doctor`), then retry.

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -33,9 +33,13 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/doctor.sh" --fix
 4. **Stuck helper processes** — a wedged `pim-helper` (usually an unanswered
    permission dialog) blocks every later call with Launch Services error
    -1712. `--fix` reaps these.
-5. **TCC authorization** per domain, prompt-free. `notDetermined` with the
-   helper installed is NORMAL for agent shells — calls route through the
-   helper, whose grant is separate and invisible to this probe.
+5. **TCC authorization** per domain, prompt-free, on both routes. The direct
+   route is what a normal terminal gets. The PIMHelper route is what an agent
+   shell gets, and it carries its own grant, bound to the helper's bundle and
+   signature. Each domain prints one line per route. `auth-status` only reads
+   the authorization status and never requests access, so probing through the
+   helper cannot raise a dialog. The helper-route probe is skipped, with a
+   warning, while a helper is already resident — only one can run at a time.
 6. **MCP server artifacts** — `dist/server.js` and node_modules.
 
 ## Interpreting results for the user
@@ -46,8 +50,23 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/doctor.sh" --fix
   immune to future renames.
 - **Stuck helper** → offer `--fix`, then have the user retry their original
   request.
+- **notDetermined on the direct route, helper installed** → normal in an agent
+  shell, and not a verdict on its own. Read the helper-route line under it.
 - **notDetermined + no helper** → run `scripts/build-helper-app.sh`, then the
   next Calendar/Reminders/Contacts call raises the macOS dialog; tell the
   user to answer it (they have ~2 minutes).
+- **helper route not granted** (failure) → calls from an agent shell will block
+  on a dialog nobody sees for up to 2 minutes, then wedge the helper. The
+  usual cause is a helper rebuild, which re-signs the bundle and drops every
+  grant. Have the user make a real Calendar / Reminders / Contacts call from a
+  normal terminal and answer the prompt.
+- **helper route not yet granted** (warning) → the same missing grant, but the
+  direct route works here, so nothing is broken until something calls from an
+  embedded shell.
+- **helper route denied** → the grant exists and is switched off. System
+  Settings > Privacy & Security > the matching section, enable PIMHelper.
+- **helper probe inconclusive** → the probe could not reach the helper: one was
+  already resident, the launch failed, or it returned nothing. Check the
+  Helper processes section, clear a stuck instance with `--fix`, re-run.
 - After any fix, verify by calling a real tool (e.g. reminder lists), not
   just by re-running doctor.

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -7,7 +7,8 @@
 #   2. PATH visibility
 #   3. PIMHelper.app (presence, signature, Launch Services)
 #   4. Stuck helper instances (the -1712 wedge)
-#   5. TCC authorization per domain (prompt-free)
+#   5. TCC authorization per domain (prompt-free) — both the direct route
+#      and the PIMHelper route, which carry independent grants
 #   6. MCP server build artifacts
 #
 # Read-only by default. `--fix` reaps stuck helper processes (the only
@@ -33,6 +34,118 @@ WARNINGS=0
 ok()   { printf "  \033[32m✓\033[0m %s\n" "$1"; }
 warn() { printf "  \033[33m⚠\033[0m %s\n" "$1"; WARNINGS=$((WARNINGS + 1)); }
 fail() { printf "  \033[31m✗\033[0m %s\n" "$1"; FAILURES=$((FAILURES + 1)); }
+
+# Domain slug -> the section name System Settings actually shows under
+# Privacy & Security. Apple's own guides say "click Privacy & Security in the
+# sidebar, then click Reminders" (and Contacts), and the calendar guide is
+# "Control access to your calendars"; this repo's error strings already agree
+# (CalendarCLI.swift, ReminderCLI.swift, skills/apple-pim/SKILL.md). Derived
+# capitalization got two of the three wrong, so the names are mapped, not
+# computed. A case statement keeps this bash-3.2-clean: macOS ships only
+# bash 3.2, where the caret case-modification substitution is a fatal "bad
+# substitution" that aborts the whole run (which is how these hints used to
+# truncate the report) and associative arrays do not exist.
+pane() {
+    case "$1" in
+        calendar) printf 'Calendars' ;;
+        reminder) printf 'Reminders' ;;
+        contacts) printf 'Contacts' ;;
+        *)        printf '%s' "$1" ;;
+    esac
+}
+
+# Matches the resident dispatcher process. Since the bundle gained a Mach-O
+# launcher, CFBundleExecutable execv()s /bin/zsh on
+# Contents/MacOS/../Resources/pim-helper.sh, so the process command line no
+# longer contains "Contents/MacOS/pim-helper" — the pattern this script used
+# before matched nothing, and every helper-process check silently passed.
+# This pattern matches both layouts and does not match the `open -W -a
+# .../PIMHelper.app` parent, whose argv carries no "Contents/".
+# NOTE: lib/cli-runner.js and openclaw/lib/cli-runner.js (line 191, identical
+# copies) still carry the old literal marker, so reapStaleHelpers() there is
+# equally blind. Fixing that touches the auto-kill path and is left separate.
+HELPER_PROC_MARKER='PIMHelper\.app/Contents/.*pim-helper'
+
+helper_resident() { pgrep -f "$HELPER_PROC_MARKER" >/dev/null 2>&1; }
+
+# Ask the helper itself what TCC says. The helper's grant binds to its bundle
+# and signature, so it is independent of this shell's — and re-signing the
+# bundle drops it, which the direct probe cannot see.
+#
+# Safe to run unattended: `auth-status` on all three CLIs reads
+# EKEventStore.authorizationStatus / CNContactStore.authorizationStatus and
+# never calls requestAccess, so it cannot raise a dialog or create a TCC row.
+#
+# Echoes the authorization string, or one of: launch-failed, timeout, unknown.
+helper_auth_status() {
+    local cli="$1" scratch waited seen_helper auth residue
+    scratch="$(mktemp -d "${TMPDIR:-/tmp}/pim-doctor.XXXXXX")" || { echo unknown; return 0; }
+    # The scratch dir is deliberately left behind: this script deletes nothing,
+    # and the OS reaps TMPDIR. Each probe leaves a few hundred bytes.
+
+    APPLE_PIM_BIN_DIR="$BIN_DIR" /usr/bin/open -W -a "$APP_PATH" --args \
+        "$cli" "$scratch/out" "$scratch/err" auth-status \
+        >/dev/null 2>"$scratch/open.err"
+    # `open -W`'s exit code is not trustworthy here: it CAN return 1 with
+    # "Unable to block on applications (initial call to kevent() failed)"
+    # even when the helper ran to completion and wrote its output (measured:
+    # rc 0 on three real launches, rc 1 only sometimes), so the exit code is
+    # ignored and the out-file is the result.
+    #
+    # stderr, by contrast, is decisive — but only read the other way round.
+    # Matching known failure strings missed a real one: a bundle with no
+    # Info.plist makes `open` print "cannot be opened because its executable
+    # is missing", which is neither -1712 nor "Unable to find application",
+    # so every domain burned its full poll and reported a false timeout. So
+    # the benign set is the allowlist and everything else is a failure.
+    #
+    # The benign set is the "Unable to block on application" family, which
+    # has more than one wording: both "applications (initial call to kevent()
+    # failed)" and "application (GetProcessPID() returned <n>)" were observed
+    # on runs whose helper wrote a complete, valid out-file, sometimes on
+    # different domains of the SAME run. Hence the prefix match — pinning the
+    # plural spelling alone reported launch-failed on a launch that worked.
+    residue="$(grep -v 'Unable to block on application' "$scratch/open.err" 2>/dev/null | tr -d '[:space:]')"
+    if [[ -n "$residue" ]]; then
+        echo "launch-failed"
+        return 0
+    fi
+
+    # `open -W` may return before the helper has even started, so absence of a
+    # resident helper is only evidence of completion once one has been seen.
+    waited=0
+    seen_helper=false
+    while (( waited < 40 )); do
+        [[ -s "$scratch/out" ]] && break
+        if helper_resident; then
+            seen_helper=true
+        elif [[ "$seen_helper" == true ]]; then
+            break
+        fi
+        sleep 0.25
+        waited=$((waited + 1))
+    done
+
+    if [[ -s "$scratch/out" ]]; then
+        auth="$(/usr/bin/python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("authorization","unknown"))
+except Exception: print("unknown")' <"$scratch/out" 2>/dev/null)"
+        echo "${auth:-unknown}"
+    elif [[ "$seen_helper" == true ]]; then
+        echo "unknown"
+    else
+        echo "timeout"
+    fi
+
+    # The dispatcher writes the out-file microseconds before it exits. Let it
+    # go before the next domain, or the single-instance helper answers the
+    # next `open` with -1712.
+    waited=0
+    while helper_resident && (( waited < 8 )); do
+        sleep 0.25
+        waited=$((waited + 1))
+    done
+}
 
 echo "apple-pim doctor"
 echo ""
@@ -117,8 +230,8 @@ while IFS= read -r pid; do
     else
         ok "pim-helper running (pid $pid, age ${etime:-?}) — likely serving a live call"
     fi
-done < <(pgrep -f "PIMHelper.app/Contents/MacOS/pim-helper" 2>/dev/null || true)
-if [[ ${#STUCK_PIDS[@]} -eq 0 ]] && ! pgrep -f "PIMHelper.app/Contents/MacOS/pim-helper" >/dev/null 2>&1; then
+done < <(pgrep -f "$HELPER_PROC_MARKER" 2>/dev/null || true)
+if [[ ${#STUCK_PIDS[@]} -eq 0 ]] && ! helper_resident; then
     ok "no resident helper processes"
 fi
 if [[ ${#STUCK_PIDS[@]} -gt 0 ]]; then
@@ -134,6 +247,18 @@ echo ""
 
 # --------------------------------------------------------------------- TCC
 echo "TCC authorization (prompt-free probe):"
+# Two routes, two grants. lib/cli-runner.js sends a call through the helper
+# whenever the direct probe says notDetermined or denied, so the helper's own
+# status is what a real call hits in exactly that case — and a helper rebuild
+# resets it without changing anything the direct probe can see.
+HELPER_INSTALLED=false
+[[ -d "$APP_PATH" && -x "$APP_PATH/Contents/MacOS/pim-helper" ]] && HELPER_INSTALLED=true
+HELPER_PROBE="$HELPER_INSTALLED"
+if [[ "$HELPER_PROBE" == true ]] && helper_resident; then
+    # One helper at a time: probing now would collide with the live call.
+    HELPER_PROBE=false
+    warn "helper busy (resident pim-helper) — helper-route probe skipped; retry after it exits or --fix"
+fi
 for cli in calendar-cli reminder-cli contacts-cli; do
     p="$BIN_DIR/$cli"
     [[ -x "$p" ]] || { fail "$cli unusable — skipping auth probe"; continue; }
@@ -146,20 +271,47 @@ except Exception: print("unknown")' 2>/dev/null)"
             ok "$domain: authorized (direct route)"
             ;;
         notDetermined)
-            if [[ -d "$APP_PATH" ]]; then
-                ok "$domain: notDetermined here, routed via PIMHelper (normal for embedded shells)"
-                echo "      If helper calls fail, the helper's own grant may be missing — its first"
-                echo "      call will raise the macOS dialog; answer it within 2 minutes."
+            if [[ "$HELPER_INSTALLED" == true ]]; then
+                if [[ "$HELPER_PROBE" == true ]]; then
+                    ok "$domain: notDetermined here (direct route) — see helper route below"
+                else
+                    ok "$domain: notDetermined here (direct route) — helper route unprobed, see above"
+                fi
             else
                 fail "$domain: notDetermined and no PIMHelper installed — no path to a grant"
             fi
             ;;
         denied)
             warn "$domain: denied for this process tree (helper route may still work;"
-            echo "      or enable in System Settings > Privacy & Security > ${domain^})"
+            echo "      or enable in System Settings > Privacy & Security > $(pane "$domain"))"
             ;;
         *)
             warn "$domain: could not determine auth status ($auth)"
+            ;;
+    esac
+
+    [[ "$HELPER_PROBE" == true ]] || continue
+    helper_auth="$(helper_auth_status "$cli")"
+    case "$helper_auth" in
+        authorized|fullAccess)
+            ok "$domain: authorized (helper route)"
+            ;;
+        notDetermined)
+            if [[ "$auth" == "authorized" || "$auth" == "fullAccess" ]]; then
+                warn "$domain: helper route not yet granted (fine from a normal terminal; the first embedded-shell call raises the macOS dialog — answer within 2 minutes)"
+            else
+                fail "$domain: helper route not granted — calls from embedded shells will block on a dialog for up to 2 minutes and wedge the helper if unanswered. Trigger it from a terminal (e.g. \`$cli auth-status\` via the helper, or any real call) and answer the prompt."
+            fi
+            ;;
+        denied)
+            if [[ "$auth" == "authorized" || "$auth" == "fullAccess" ]]; then
+                warn "$domain: helper route denied (direct route works here; enable PIMHelper in System Settings > Privacy & Security > $(pane "$domain") for embedded shells)"
+            else
+                fail "$domain: helper route denied — enable PIMHelper in System Settings > Privacy & Security > $(pane "$domain")"
+            fi
+            ;;
+        *)
+            warn "$domain: helper probe inconclusive ($helper_auth) — see Helper processes above; retry when no helper is resident"
             ;;
     esac
 done


### PR DESCRIPTION
## What this fixes

`scripts/doctor.sh` check 5 runs `auth-status` on the direct route only. When the direct probe reads `notDetermined` and the helper bundle exists, it prints an ok line saying calls route via PIMHelper and stops. It never asks the helper anything. That is the one case where the helper's own grant decides the outcome: `lib/cli-runner.js probeRoute()` sends a call through the helper whenever the direct probe reads `notDetermined` or `denied`.

Re-signing the helper bundle drops its grants, and `build-helper-app.sh` re-signs on any content change or `--force`. After that, doctor keeps reporting normal while every call from an agent shell blocks on a permission dialog for two minutes, then wedges the single-instance helper for everything behind it.

Check 5 now probes both routes and prints one line per route per domain. The helper line carries the verdict when the direct route cannot: not granted is a failure when the direct route is also unavailable, a warning when the direct route works and only embedded shells are affected. The probe is skipped, with a warning, while a helper is already resident.

## Why probing through the helper cannot prompt

`auth-status` on all three CLIs is a plain `EKEventStore.authorizationStatus` / `CNContactStore.authorizationStatus` read (`CalendarCLI.swift:37`, `ReminderCLI.swift:42`, `ContactsCLI.swift:37`). None of them call `requestAccess`, so the probe can neither raise a dialog nor create a TCC row, whichever route it takes.

## Two pre-existing defects fixed on the way

Both sit in check 4/5 and the new probe depends on them.

- The `pgrep` pattern for a resident helper still described the pre-launcher bundle layout. Since the Mach-O launcher (#110), `CFBundleExecutable` execs `/bin/zsh` on `Contents/MacOS/../Resources/pim-helper.sh`, so no live process ever matched `Contents/MacOS/pim-helper`. The stuck-helper check found nothing and always reported all clear. The new pattern matches both layouts. `lib/cli-runner.js:191` carries the same stale literal, which leaves `reapStaleHelpers()` equally blind; I left that alone here because it kills processes and deserves its own change.
- The System Settings hints used `${var^}`, a bash 4 substitution. macOS ships bash 3.2, so on the documented invocation (`bash scripts/doctor.sh`) the `denied` branch died with "bad substitution" mid-report and still exited 0 with "Result: healthy". Replaced with a slug-to-pane map that also names the panes System Settings shows (Calendars, Reminders, Contacts).

## Handling `open -W`

`open -W` returns 1 with "Unable to block on application(s) …" on some runs where the helper completed and wrote its output, so the probe ignores the exit code and reads the out-file. Anything else `open` writes to stderr counts as a launch failure (a bundle without `Info.plist` prints "cannot be opened because its executable is missing", which no fixed string list caught). The wait is a bounded poll, since `-W` can return before the helper starts. The probe leaves its `mktemp` scratch directory in `TMPDIR`; the script deletes nothing.

## How I tested

Real helper, real binaries, on a machine where the helper holds all three grants: doctor prints authorized on both routes for all three domains, exit 0, no dialog, nothing resident afterwards, whole run under one second.

Every other branch ran through the real helper with stub CLIs, no EventKit and no TCC involved. `APPLE_PIM_BIN_DIR` points doctor and the dispatcher at a directory of shell stubs that answer one thing when run directly and another when the helper dispatcher is one of their ancestors:

| direct → helper | result |
|---|---|
| authorized → authorized | ok on both routes, exit 0 |
| notDetermined → authorized | ok "authorized (helper route)", exit 0 |
| notDetermined → notDetermined | fail "helper route not granted", exit 1 |
| authorized → notDetermined | warn "helper route not yet granted", exit 0 |
| notDetermined → denied | fail "helper route denied", exit 1 |
| authorized → denied | warn, exit 0 |
| denied → denied | pane names print, script runs to completion (this branch used to abort) |
| notDetermined → non-JSON | warn "inconclusive (unknown)" |
| notDetermined → no output for 20 s | warn "inconclusive (timeout)", nothing resident at exit |
| helper resident (stub sleeping 45 s) | warn "helper busy" once, all three probes skipped, no -1712, sleeping helper untouched |
| bundle without Info.plist | warn "inconclusive (launch-failed)" ×3 in 0.2 s instead of three 10 s timeouts |
| helper not installed | output byte-identical to the current script, same exit code |

`bash -n` passes under bash 3.2. shellcheck was not available on the test machine.
