### PR TITLE
refactor(mail): use OpenClaw ingress authentication kernel

### DIFF
--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -16,11 +16,11 @@
       "./src/index.ts"
     ],
     "compat": {
-      "pluginApi": ">=2026.6.5"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.6.5",
-      "pluginSdkVersion": "2026.6.5"
+      "openclawVersion": "2026.8.1",
+      "pluginSdkVersion": "2026.8.1"
     },
     "environment": {
       "binaries": [
@@ -87,7 +87,7 @@
     "turndown": "^7.2.2"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.5"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -100,6 +100,6 @@
     "@types/node": "^25.5.0",
     "@types/mailparser": "^3.4.6",
     "tsup": "^8.5.0",
-    "openclaw": ">=2026.6.5"
+    "openclaw": ">=2026.8.1"
   }
 }

--- a/openclaw/src/mail-auth/strength.test.ts
+++ b/openclaw/src/mail-auth/strength.test.ts
@@ -2,10 +2,30 @@ import { describe, it } from "node:test";
 import { strict as assert } from "node:assert";
 import {
   mailAuthToIdentifierStrengths,
-  meetsMinimum,
-  weakest,
+  type IdentifierAuthentication,
   type MailAuthCheckResult,
 } from "./strength.ts";
+
+const authenticationRank: Record<IdentifierAuthentication, number> = {
+  verified: 3,
+  asserted: 2,
+  unverified: 1,
+  mutable: 0,
+};
+
+function meetsMinimum(
+  actual: IdentifierAuthentication,
+  minimum: IdentifierAuthentication,
+): boolean {
+  return authenticationRank[actual] >= authenticationRank[minimum];
+}
+
+function weakest(
+  a: IdentifierAuthentication,
+  b: IdentifierAuthentication,
+): IdentifierAuthentication {
+  return meetsMinimum(a, b) ? b : a;
+}
 
 /** Builds an auth-check result without restating unrelated fields in every case. */
 function result(overrides: Partial<MailAuthCheckResult> = {}): MailAuthCheckResult {

--- a/openclaw/src/mail-auth/strength.ts
+++ b/openclaw/src/mail-auth/strength.ts
@@ -1,18 +1,20 @@
 /**
  * Maps `mail-cli auth-check` output onto per-identifier authentication strength.
  *
- * This is the shim boundary for OpenClaw RFC 0027
- * (https://github.com/openclaw/rfcs/pull/51). Core does not yet ship
- * `IdentifierAuthentication`, so the type is declared locally and the gate is applied
- * plugin-side. When the kernel lands the primitive, this module keeps its logic and only
- * its consumers change: the strengths below are handed to the ingress subject instead of
- * being enforced here.
+ * This was the shim boundary for OpenClaw RFC 0028
+ * (https://github.com/openclaw/rfcs/pull/51) while core did not yet ship
+ * `IdentifierAuthentication`. The kernel primitive now exists
+ * (openclaw/openclaw#123782), so the type comes from the plugin SDK and the gate runs in
+ * the ingress kernel: this module keeps its verdict→strength logic, and its consumers hand
+ * the strengths to the ingress subject instead of enforcing a minimum here.
  *
  * The invariant this module exists to hold: strength is derived only from transport
  * metadata that our own boundary authenticated, never from sender-controlled message
  * content. `mail-cli auth-check` enforces the provenance half (authserv-id pinning, SPF
  * alignment); this module refuses to promote anything it cannot justify.
  */
+
+import type { IdentifierAuthentication } from "openclaw/plugin-sdk/channel-ingress-runtime";
 
 /**
  * Ordered authentication strength. Mirrors the RFC 0027 scale.
@@ -28,30 +30,7 @@
  * wrong reason, which is how a diagnostic ends up describing a precise address as a
  * nickname. The RFC gained the fourth level after implementing it here surfaced the gap.
  */
-export type IdentifierAuthentication = "verified" | "asserted" | "unverified" | "mutable";
-
-const RANK: Record<IdentifierAuthentication, number> = {
-  verified: 3,
-  asserted: 2,
-  unverified: 1,
-  mutable: 0,
-};
-
-/** Returns true when `actual` meets or exceeds the required minimum. */
-export function meetsMinimum(
-  actual: IdentifierAuthentication,
-  minimum: IdentifierAuthentication,
-): boolean {
-  return RANK[actual] >= RANK[minimum];
-}
-
-/** Returns the weaker of two strengths, which is how entry and subject sides combine. */
-export function weakest(
-  a: IdentifierAuthentication,
-  b: IdentifierAuthentication,
-): IdentifierAuthentication {
-  return RANK[a] <= RANK[b] ? a : b;
-}
+export type { IdentifierAuthentication };
 
 /** Verdict vocabulary emitted by `mail-cli auth-check`. */
 export type MailAuthVerdict = "verified" | "suspicious" | "unknown" | "untrusted";

--- a/openclaw/src/mail-channel/inbound.ts
+++ b/openclaw/src/mail-channel/inbound.ts
@@ -9,9 +9,32 @@
  * belongs instead of upstream where it would decide what the agent is allowed to see.
  */
 
-import { mailAuthToIdentifierStrengths, type MailAuthCheckResult } from "../mail-auth/strength.ts";
-import { decideIngress, type IngressDecision, type IngressInput } from "./policy.ts";
+import {
+  defineStableChannelIngressIdentity,
+  resolveChannelMessageIngress,
+} from "openclaw/plugin-sdk/channel-ingress-runtime";
+import {
+  mailAuthToIdentifierStrengths,
+  type IdentifierAuthentication,
+  type MailAuthCheckResult,
+  type MailIdentifierStrengths,
+} from "../mail-auth/strength.ts";
+import { decideIngress, type IngressDecision } from "./policy.ts";
 import { decideThreadReply, type AgentThreadRecord } from "./thread.ts";
+
+/**
+ * Identity contract this channel presents to the ingress kernel.
+ *
+ * Entry-side `verified` states that an email address exactly names its holder; what any
+ * *message* proved arrives per message on the subject side, so the kernel's
+ * min(entry, subject) resolves to exactly the strength `mail-cli auth-check` established.
+ */
+const MAIL_INGRESS_IDENTITY = defineStableChannelIngressIdentity({
+  key: "email",
+  normalize: (value: string) => value.trim().toLowerCase(),
+  sensitivity: "pii",
+  authentication: "verified",
+});
 
 /** One row as listed by `mail-cli messages`. */
 export type MailboxMessage = {
@@ -151,6 +174,11 @@ export type ClassifiedMessage = {
   address: string;
   decision: IngressDecision;
   /**
+   * The kernel's own reason code for the ingress outcome, carried for receipts and
+   * diagnostics. The channel-level `decision.reason` stays the product vocabulary.
+   */
+  kernelReasonCode: string;
+  /**
    * Which conversation this message belongs to, for session scoping.
    *
    * The anchor the agent already recorded for the thread when the claim resolves to one,
@@ -161,7 +189,9 @@ export type ClassifiedMessage = {
   threadKey: string;
 };
 
-export type ClassifyOptions = Pick<IngressInput, "minIdentifierAuthentication"> & {
+export type ClassifyOptions = {
+  /** Minimum strength an identifier needs before it may authorize. */
+  minIdentifierAuthentication: IdentifierAuthentication;
   /**
    * Configured inbound allowlist. Membership is derived per message rather than passed
    * as a boolean: the caller does not know the sender address until this function has
@@ -215,17 +245,75 @@ export async function classifyMessage(
     }
   }
 
-  return {
-    message,
+  const resolved = await resolveMailIngress({
     address,
-    threadKey,
+    strengths,
+    allowFrom: options.allowFrom ?? [],
+    allowlisted,
+    selfAddressed,
+    threadPermitted,
+    minIdentifierAuthentication: options.minIdentifierAuthentication,
+    conversationId: threadKey,
+  });
+
+  return { message, address, threadKey, ...resolved };
+}
+
+export type MailIngressParams = {
+  /** Sender address, already normalized. */
+  address: string;
+  strengths: MailIdentifierStrengths;
+  allowFrom: readonly string[];
+  allowlisted: boolean;
+  selfAddressed: boolean;
+  threadPermitted: boolean;
+  minIdentifierAuthentication: IdentifierAuthentication;
+  /** Conversation the kernel scopes this resolution to; the thread key in practice. */
+  conversationId: string;
+};
+
+/**
+ * The channel's single admission path: the ingress kernel decides allowlist plus
+ * authentication, then channel policy layers the loop guard and observe escalation.
+ *
+ * Exported so the scenario suite proves the same wiring `classifyMessage` runs, rather
+ * than a parallel reimplementation that could drift.
+ */
+export async function resolveMailIngress(
+  params: MailIngressParams,
+): Promise<{ decision: IngressDecision; kernelReasonCode: string }> {
+  // Thread permission enters the kernel as an injected allowlist entry: the agent already
+  // chose to contact this person when it started the thread, so the *allowlist* is waived,
+  // while the injected entry's subject-side strength is still gated like any other. The
+  // authentication half of the thread rule therefore runs in the kernel, not here.
+  const effectiveAllowFrom =
+    params.threadPermitted && !params.allowlisted
+      ? [...params.allowFrom, params.address]
+      : [...params.allowFrom];
+
+  const kernel = await resolveChannelMessageIngress({
+    channelId: "apple-mail",
+    accountId: "default",
+    identity: MAIL_INGRESS_IDENTITY,
+    subject: { stableId: params.address, authentication: { email: params.strengths.address } },
+    conversation: { kind: "direct", id: params.conversationId },
+    event: { kind: "message", authMode: "inbound", mayPair: false },
+    policy: {
+      dmPolicy: "allowlist",
+      groupPolicy: "disabled",
+      minIdentifierAuthentication: params.minIdentifierAuthentication,
+    },
+    allowFrom: effectiveAllowFrom,
+  });
+
+  return {
+    kernelReasonCode: kernel.ingress.reasonCode,
     decision: decideIngress({
-      strengths,
-      senderAddress: address,
-      allowlisted,
-      minIdentifierAuthentication: options.minIdentifierAuthentication,
-      selfAddressed,
-      threadPermitted,
+      kernelAdmitted: kernel.ingress.admission === "dispatch",
+      domainVerified: params.strengths.domain === "verified",
+      allowlisted: params.allowlisted,
+      selfAddressed: params.selfAddressed,
+      threadPermitted: params.threadPermitted,
     }),
   };
 }

--- a/openclaw/src/mail-channel/policy.test.ts
+++ b/openclaw/src/mail-channel/policy.test.ts
@@ -1,33 +1,16 @@
 import { describe, it } from "node:test";
 import { strict as assert } from "node:assert";
 import { decideEgress, decideIngress, type IngressInput } from "./policy.ts";
-import type { MailIdentifierStrengths } from "../mail-auth/strength.ts";
 
-const VERIFIED: MailIdentifierStrengths = {
-  address: "verified",
-  domain: "verified",
-  displayName: "mutable",
-};
-const AUTHENTICATED_STRANGER: MailIdentifierStrengths = {
-  address: "asserted",
-  domain: "verified",
-  displayName: "mutable",
-};
-// Nothing authenticated, so both identifiers are `unverified`: presented by a party nobody
-// vouched for. `asserted` here would model a state the mapper cannot produce and would stop
-// these cases distinguishing a proven domain from an unproven one.
-const UNAUTHENTICATED: MailIdentifierStrengths = {
-  address: "unverified",
-  domain: "unverified",
-  displayName: "mutable",
-};
-
+// The authentication gate itself (minimums, per-message strengths, break-glass) moved into
+// the ingress kernel and is proven end to end by scenarios.test.ts through
+// `resolveMailIngress`. What remains here is the channel's pure layering over the kernel's
+// answer: loop guard, grant attribution, and the observe escalation.
 function ingress(overrides: Partial<IngressInput> = {}): IngressInput {
   return {
-    strengths: VERIFIED,
-    senderAddress: "operator@example.com",
+    kernelAdmitted: true,
+    domainVerified: true,
     allowlisted: true,
-    minIdentifierAuthentication: "verified",
     selfAddressed: false,
     threadPermitted: false,
     ...overrides,
@@ -35,16 +18,16 @@ function ingress(overrides: Partial<IngressInput> = {}): IngressInput {
 }
 
 describe("ingress admission", () => {
-  it("I1: dispatches an authenticated, allowlisted sender", () => {
+  it("I1: dispatches a kernel-admitted, allowlisted sender", () => {
     assert.deepEqual(decideIngress(ingress()), {
       admission: "dispatch",
       reason: "allowlisted_and_authenticated",
     });
   });
 
-  it("I2: drops an allowlisted sender whose message did not authenticate", () => {
+  it("I2: drops an allowlisted sender the kernel rejected with nothing proven", () => {
     // The operator gets no exception. Making one would invert the whole model.
-    assert.deepEqual(decideIngress(ingress({ strengths: UNAUTHENTICATED })), {
+    assert.deepEqual(decideIngress(ingress({ kernelAdmitted: false, domainVerified: false })), {
       admission: "drop",
       reason: "identifier_authentication_too_weak",
     });
@@ -52,75 +35,56 @@ describe("ingress admission", () => {
 
   it("I5: observes an authenticated stranger, never dispatches", () => {
     assert.deepEqual(
-      decideIngress(ingress({ strengths: AUTHENTICATED_STRANGER, allowlisted: false })),
+      decideIngress(ingress({ kernelAdmitted: false, allowlisted: false, domainVerified: true })),
       { admission: "observe", reason: "authenticated_but_not_allowlisted" },
     );
   });
 
-  it("I6: drops an unauthenticated stranger", () => {
-    assert.deepEqual(decideIngress(ingress({ strengths: UNAUTHENTICATED, allowlisted: false })), {
-      admission: "drop",
-      reason: "unauthenticated_sender",
+  it("I4a: an allowlisted sender the kernel rejected still observes on a proven domain", () => {
+    // The inversion guard: enrolling someone must never reduce what the channel does
+    // with their mail relative to the identical unenrolled sender.
+    assert.deepEqual(decideIngress(ingress({ kernelAdmitted: false, domainVerified: true })), {
+      admission: "observe",
+      reason: "identifier_authentication_too_weak",
     });
   });
 
-  it("I7/I8: a forged or unaligned pass lands as unauthenticated, not as a stranger to read", () => {
-    // Both attacks resolve to unverified/unverified upstream, so they cannot reach observe:
-    // the `observe` branch needs a verified domain, and nothing proved one.
-    const forged = decideIngress(ingress({ strengths: UNAUTHENTICATED, allowlisted: false }));
-    assert.equal(forged.admission, "drop");
+  it("I6: drops an unauthenticated stranger", () => {
+    assert.deepEqual(
+      decideIngress(ingress({ kernelAdmitted: false, allowlisted: false, domainVerified: false })),
+      { admission: "drop", reason: "unauthenticated_sender" },
+    );
   });
 
   it("I13: drops self-addressed mail before any grant applies", () => {
-    // Loop guard must outrank thread permission, which would otherwise dispatch it.
+    // Loop guard must outrank the kernel admit, which would otherwise dispatch it.
     assert.deepEqual(decideIngress(ingress({ selfAddressed: true, threadPermitted: true })), {
       admission: "drop",
       reason: "self_addressed",
     });
   });
 
-  it("thread permission waives the allowlist but not authentication", () => {
-    // Greptile P1: an attacker who learns a participant's address and an agent
-    // Message-ID could otherwise spoof From and inherit the thread grant.
-    assert.deepEqual(
-      decideIngress(
-        ingress({ allowlisted: false, strengths: UNAUTHENTICATED, threadPermitted: true }),
-      ),
-      { admission: "drop", reason: "identifier_authentication_too_weak" },
-    );
+  it("I9: attributes a kernel admit through the injected thread entry to the thread grant", () => {
+    assert.deepEqual(decideIngress(ingress({ allowlisted: false, threadPermitted: true })), {
+      admission: "dispatch",
+      reason: "thread_originated_by_agent",
+    });
   });
 
-  it("I9: dispatches a thread reply from a sender who is not allowlisted", () => {
+  it("thread permission waives the allowlist but not authentication", () => {
+    // Greptile P1: an attacker who learns a participant's address and an agent
+    // Message-ID could otherwise spoof From and inherit the thread grant. The kernel
+    // rejecting the injected entry lands as too-weak, not as a dispatch.
     assert.deepEqual(
       decideIngress(
         ingress({
+          kernelAdmitted: false,
           allowlisted: false,
-          strengths: VERIFIED,
           threadPermitted: true,
+          domainVerified: false,
         }),
       ),
-      { admission: "dispatch", reason: "thread_originated_by_agent" },
-    );
-  });
-
-  // This test used to assert the opposite, and passed only because the fixture above scored
-  // an unauthenticated address `asserted`. It was the original bypass written down as
-  // expected behavior: allowlisted plus the shipped default minimum, admitted with nothing
-  // authenticated. Correcting the fixture surfaced it.
-  it("drops an allowlisted sender who authenticated nothing, at the shipped default", () => {
-    const decision = decideIngress(
-      ingress({ strengths: UNAUTHENTICATED, minIdentifierAuthentication: "asserted" }),
-    );
-    assert.equal(decision.admission, "drop");
-    assert.equal(decision.reason, "identifier_authentication_too_weak");
-  });
-
-  it("admits that same sender only under the break-glass minimum", () => {
-    assert.equal(
-      decideIngress(
-        ingress({ strengths: UNAUTHENTICATED, minIdentifierAuthentication: "mutable" }),
-      ).admission,
-      "dispatch",
+      { admission: "drop", reason: "identifier_authentication_too_weak" },
     );
   });
 });

--- a/openclaw/src/mail-channel/policy.ts
+++ b/openclaw/src/mail-channel/policy.ts
@@ -10,9 +10,6 @@
  *   - every default is closed
  */
 
-import type { IdentifierAuthentication, MailIdentifierStrengths } from "../mail-auth/strength.ts";
-import { meetsMinimum } from "../mail-auth/strength.ts";
-
 /** What the channel does with an inbound message. */
 export type Admission = "dispatch" | "observe" | "drop";
 
@@ -30,13 +27,17 @@ export type IngressDecision = {
 };
 
 export type IngressInput = {
-  strengths: MailIdentifierStrengths;
-  /** Sender address, already normalized. */
-  senderAddress: string;
-  /** True when the sender matches an inbound allowlist entry or the operator. */
+  /**
+   * The ingress kernel's admission for this message: allowlist matching and the
+   * min(entry, subject) authentication gate, decided together in core
+   * (`resolveChannelMessageIngress`). Thread permission is expressed to the kernel as an
+   * injected allowlist entry, so a kernel admit already implies sufficient authentication.
+   */
+  kernelAdmitted: boolean;
+  /** True when the transport proved the sender's *domain*; feeds the observe escalation. */
+  domainVerified: boolean;
+  /** True when the sender matches a configured inbound allowlist entry or the operator. */
   allowlisted: boolean;
-  /** Minimum strength an identifier needs before it may authorize. */
-  minIdentifierAuthentication: IdentifierAuthentication;
   /** True when this message came from an address the agent itself sends as. */
   selfAddressed: boolean;
   /** Result of the thread rule, when the message claims thread membership. */
@@ -44,14 +45,14 @@ export type IngressInput = {
 };
 
 /**
- * Decides admission for one inbound message.
+ * Layers channel product policy over the kernel's admission.
  *
- * Order matters and is deliberate:
+ * The kernel owns "may this sender authorize a run": allowlist ∧ authentication strength.
+ * This function owns what the *channel* does around that answer, and order matters:
  *   1. loop guard, before any policy can grant anything
- *   2. thread permission, which is narrower than the allowlist and independent of it
- *   3. allowlist plus sufficient address strength
- *   4. authenticated-but-unknown, which is readable and nothing more
- *   5. everything else
+ *   2. the kernel's admit, attributed to the grant that carried it
+ *   3. authenticated-but-unknown, which is readable and nothing more
+ *   4. everything else
  */
 export function decideIngress(input: IngressInput): IngressDecision {
   // I13. An agent that can send and read mail can answer itself.
@@ -59,23 +60,14 @@ export function decideIngress(input: IngressInput): IngressDecision {
     return { admission: "drop", reason: "self_addressed" };
   }
 
-  const addressStrongEnough = meetsMinimum(
-    input.strengths.address,
-    input.minIdentifierAuthentication,
-  );
-
-  // I9. Thread permission waives the *allowlist*, because the agent already chose to
-  // contact this person when it started the thread. It does not waive *authentication*.
-  // decideThreadReply matches on the sender address, and an unauthenticated address is a
-  // claim: anyone who learns a participant's address and an agent Message-ID could
-  // otherwise spoof their way into a dispatch.
-  if (input.threadPermitted && addressStrongEnough) {
-    return { admission: "dispatch", reason: "thread_originated_by_agent" };
-  }
-
-  // I1, I4.
-  if (input.allowlisted && addressStrongEnough) {
-    return { admission: "dispatch", reason: "allowlisted_and_authenticated" };
+  // I1, I4, I9. The kernel admitted the sender through an allowlist entry with sufficient
+  // per-message strength. Thread permission waives the *allowlist*, never *authentication*:
+  // it enters the kernel as an injected entry whose subject-side strength is still gated,
+  // so an admit through only that entry is the thread grant in kernel clothing.
+  if (input.kernelAdmitted) {
+    return input.allowlisted
+      ? { admission: "dispatch", reason: "allowlisted_and_authenticated" }
+      : { admission: "dispatch", reason: "thread_originated_by_agent" };
   }
 
   // I5, I11, I4a. The transport proved a domain; nothing proved this human may direct an
@@ -87,7 +79,7 @@ export function decideIngress(input: IngressInput): IngressDecision {
   // dropping them here would mean adding someone to `allowFrom` *reduced* what the channel
   // does with their mail. That inversion is silent, and it lands on exactly the addresses
   // the operator cared enough to configure.
-  if (input.strengths.domain === "verified") {
+  if (input.domainVerified) {
     return {
       admission: "observe",
       reason:

--- a/openclaw/src/mail-channel/scenarios.test.ts
+++ b/openclaw/src/mail-channel/scenarios.test.ts
@@ -17,10 +17,12 @@ import { describe, it } from "node:test";
 import { strict as assert } from "node:assert";
 import {
   mailAuthToIdentifierStrengths,
+  type IdentifierAuthentication,
   type MailAuthCheckResult,
   type MailIdentifierStrengths,
 } from "../mail-auth/strength.ts";
-import { decideIngress, type Admission } from "./policy.ts";
+import { resolveMailIngress } from "./inbound.ts";
+import type { Admission } from "./policy.ts";
 
 const OPERATOR = "operator@example.com";
 
@@ -239,27 +241,44 @@ const ROWS: Row[] = [
   },
 ];
 
+/**
+ * Runs one scenario row through the real ingress kernel via the channel's single
+ * admission path, so this table proves `resolveChannelMessageIngress` end to end
+ * rather than a local reimplementation of its gate.
+ */
+async function admissionFor(
+  row: Pick<Row, "auth" | "allowlisted" | "selfAddressed" | "threadPermitted">,
+  minimum: IdentifierAuthentication,
+): Promise<Admission> {
+  const strengths = mailAuthToIdentifierStrengths(row.auth);
+  const address = row.auth.sender ?? "sender@example.test";
+  const resolved = await resolveMailIngress({
+    address,
+    strengths,
+    allowFrom: row.allowlisted ? [address] : [],
+    allowlisted: row.allowlisted ?? false,
+    selfAddressed: row.selfAddressed ?? false,
+    threadPermitted: row.threadPermitted ?? false,
+    minIdentifierAuthentication: minimum,
+    conversationId: "scenario-thread",
+  });
+  return resolved.decision.admission;
+}
+
 describe("scenario doc: ingress table", () => {
   for (const row of ROWS) {
-    it(`${row.id}: ${row.what}`, () => {
+    it(`${row.id}: ${row.what}`, async () => {
       const strengths = mailAuthToIdentifierStrengths(row.auth);
       assert.equal(strengths.address, row.strengths.address, "address strength");
       assert.equal(strengths.domain, row.strengths.domain, "domain strength");
 
-      const input = {
-        strengths,
-        senderAddress: row.auth.sender ?? "",
-        allowlisted: row.allowlisted ?? false,
-        selfAddressed: row.selfAddressed ?? false,
-        threadPermitted: row.threadPermitted ?? false,
-      };
       assert.equal(
-        decideIngress({ ...input, minIdentifierAuthentication: "asserted" }).admission,
+        await admissionFor(row, "asserted"),
         row.atDefault,
         "at the default `asserted` minimum",
       );
       assert.equal(
-        decideIngress({ ...input, minIdentifierAuthentication: "verified" }).admission,
+        await admissionFor(row, "verified"),
         row.atStrict,
         "at the strict `verified` minimum",
       );
@@ -274,22 +293,14 @@ describe("scenario doc: invariants across the table", () => {
   // allowlisted-but-unenrolled sender dropped, while the identical message from a sender
   // *not* on the allowlist was admitted to `observe`. Enrolling someone must never reduce
   // what the channel does with their mail.
-  it("adding a sender to allowFrom never lowers their admission", () => {
+  it("adding a sender to allowFrom never lowers their admission", async () => {
     for (const row of ROWS) {
       if (row.selfAddressed) {
         continue;
       }
-      const strengths = mailAuthToIdentifierStrengths(row.auth);
       for (const minimum of ["asserted", "verified"] as const) {
-        const base = {
-          strengths,
-          senderAddress: row.auth.sender ?? "",
-          selfAddressed: false,
-          threadPermitted: row.threadPermitted ?? false,
-          minIdentifierAuthentication: minimum,
-        };
-        const off = decideIngress({ ...base, allowlisted: false }).admission;
-        const on = decideIngress({ ...base, allowlisted: true }).admission;
+        const off = await admissionFor({ ...row, allowlisted: false }, minimum);
+        const on = await admissionFor({ ...row, allowlisted: true }, minimum);
         assert.ok(
           RANK[on] >= RANK[off],
           `${row.id} at ${minimum}: allowlisted=${on} is weaker than allowlisted=false=${off}`,
@@ -300,22 +311,14 @@ describe("scenario doc: invariants across the table", () => {
 
   // Same argument for the other grant. Thread permission is a grant, and a grant that
   // cannot be exercised must leave the sender exactly where an ungranted one lands.
-  it("thread permission never lowers admission", () => {
+  it("thread permission never lowers admission", async () => {
     for (const row of ROWS) {
       if (row.selfAddressed) {
         continue;
       }
-      const strengths = mailAuthToIdentifierStrengths(row.auth);
       for (const minimum of ["asserted", "verified"] as const) {
-        const base = {
-          strengths,
-          senderAddress: row.auth.sender ?? "",
-          selfAddressed: false,
-          allowlisted: row.allowlisted ?? false,
-          minIdentifierAuthentication: minimum,
-        };
-        const off = decideIngress({ ...base, threadPermitted: false }).admission;
-        const on = decideIngress({ ...base, threadPermitted: true }).admission;
+        const off = await admissionFor({ ...row, threadPermitted: false }, minimum);
+        const on = await admissionFor({ ...row, threadPermitted: true }, minimum);
         assert.ok(
           RANK[on] >= RANK[off],
           `${row.id} at ${minimum}: threadPermitted=${on} is weaker than ungranted=${off}`,
@@ -352,22 +355,14 @@ describe("scenario doc: invariants across the table", () => {
   // channel never scores an address or domain `mutable`, so the two weakest minimums admit
   // the same mail. If a future mapping emits `mutable` for an address, that stops being true
   // and this fails, which is the point.
-  it("treats `unverified` and `mutable` as the same minimum, which is why only one is configurable", () => {
+  it("treats `unverified` and `mutable` as the same minimum, which is why only one is configurable", async () => {
     for (const row of ROWS) {
       if (row.selfAddressed) {
         continue;
       }
-      const strengths = mailAuthToIdentifierStrengths(row.auth);
-      const base = {
-        strengths,
-        senderAddress: row.auth.sender ?? "",
-        allowlisted: row.allowlisted ?? false,
-        selfAddressed: false,
-        threadPermitted: row.threadPermitted ?? false,
-      };
       assert.equal(
-        decideIngress({ ...base, minIdentifierAuthentication: "unverified" }).admission,
-        decideIngress({ ...base, minIdentifierAuthentication: "mutable" }).admission,
+        await admissionFor(row, "unverified"),
+        await admissionFor(row, "mutable"),
         row.id,
       );
     }
@@ -375,17 +370,10 @@ describe("scenario doc: invariants across the table", () => {
 
   // And the break-glass value is genuinely break-glass: it admits what the real postures
   // reject, so nobody reads the equivalence above as "the weak setting is safe".
-  it("the break-glass minimum does admit what the supported ones drop", () => {
+  it("the break-glass minimum does admit what the supported ones drop", async () => {
     const spoofed = ROWS.find((r) => r.id === "I7");
     assert.ok(spoofed, "I7 is the spoofed-operator row");
-    const decision = decideIngress({
-      strengths: mailAuthToIdentifierStrengths(spoofed.auth),
-      senderAddress: spoofed.auth.sender ?? "",
-      allowlisted: true,
-      selfAddressed: false,
-      threadPermitted: false,
-      minIdentifierAuthentication: "mutable",
-    });
-    assert.equal(decision.admission, "dispatch", "break-glass means exactly that");
+    const admission = await admissionFor({ auth: spoofed.auth, allowlisted: true }, "mutable");
+    assert.equal(admission, "dispatch", "break-glass means exactly that");
   });
 });


### PR DESCRIPTION
## Summary

- replace Apple Mail's plugin-local ingress authentication gate with OpenClaw's channel ingress kernel
- pass the stable email identity and per-message authentication strength to `resolveChannelMessageIngress`
- keep only Mail-specific loop prevention, thread attribution, and observe-only behavior in plugin policy
- raise the OpenClaw Plugin SDK compatibility floor to 2026.8.1

## Security model

OpenClaw core now owns the allowlist plus identifier-authentication decision. The plugin derives email authentication strength only from trusted transport metadata and supplies that claim to the kernel. Thread permission is represented as an effective allowlist entry, so it waives allowlist enrollment but never the authentication minimum.

Self-address loop prevention still runs before any grant. Authenticated but unenrolled mail remains observe-only, and unauthenticated mail remains dropped.

## Validation

- `node --test src/mail-auth/strength.test.ts src/mail-channel/policy.test.ts` (40 passing)
- `npm run build`
- `npm run plugin:check` (PASS, zero breakages)
- `git diff --check`

The locally installed OpenClaw 2026.6.5 package exports the earlier resolver shape but does not enforce per-message identifier strength. Running the complete suite against it fails the eight expected authentication-gate scenarios, which is why this PR raises the minimum host version to 2026.8.1. The preserved precursor branch was previously validated against the #123793 SDK build with all 244 tests passing.