### PR TITLE
ci: gate publishing on the SDK contract, and start running the openclaw suite

### DIFF
--- a/.github/actions/openclaw-sdk-contract/action.yml
+++ b/.github/actions/openclaw-sdk-contract/action.yml
@@ -88,19 +88,41 @@ runs:
           exit 0
         fi
 
-        # Three assertions, one per thing openclaw/src/mail-channel/inbound.ts depends on:
-        # the module it imports from, the function it calls, and the policy field it
-        # passes. The field matters most: it is an ordinary property, so an SDK without
-        # it drops the value silently and the authentication gate stops running with
-        # nothing raised anywhere.
+        # Extract rather than stream. Two reasons, both load-bearing:
+        #
+        # 1. `tar ... | grep -q` is a false-NEGATIVE generator under `pipefail`. `grep -q`
+        #    exits 0 at its first match and closes the pipe, `tar` then takes SIGPIPE (141),
+        #    and `pipefail` makes the PIPELINE non-zero even though the capability WAS
+        #    found. The `|| MISSING=` branch would record a present symbol as absent and
+        #    block every publish workflow against a perfectly good SDK. It is racy on how
+        #    much output precedes the match, so it would also fail intermittently. `grep -r`
+        #    over files runs no pipeline and cannot hit this.
+        # 2. Slurping `tar xzO` into a shell variable mangles the package anyway: command
+        #    substitution strips NUL bytes and openclaw ships binaries.
+        mkdir -p "$WORK/x"
+        tar xzf "$WORK/sdk.tgz" -C "$WORK/x" 2>/dev/null || true
+
+        # Every assertion is scoped to the SHIPPED RUNTIME. npm packs `docs/` (confirmed:
+        # docs/plugins/sdk-channel-ingress.md), so searching the whole tarball would let a
+        # release that merely DOCUMENTS this contract pass a probe asking whether it
+        # IMPLEMENTS it. npm tarballs always root at `package/`.
+        DIST="$WORK/x/package/dist"
+
         MISSING=""
-        tar tzf "$WORK/sdk.tgz" 2>/dev/null | grep -q 'plugin-sdk/channel-ingress-runtime' \
-          || MISSING="$MISSING plugin-sdk/channel-ingress-runtime"
-        CONTENTS="$(tar xzOf "$WORK/sdk.tgz" 2>/dev/null || true)"
-        printf '%s' "$CONTENTS" | grep -q 'resolveChannelMessageIngress' \
-          || MISSING="$MISSING resolveChannelMessageIngress"
-        printf '%s' "$CONTENTS" | grep -q 'minIdentifierAuthentication' \
-          || MISSING="$MISSING minIdentifierAuthentication"
+        ls "$DIST"/plugin-sdk/channel-ingress-runtime.* >/dev/null 2>&1 \
+          || MISSING="$MISSING dist/plugin-sdk/channel-ingress-runtime"
+
+        # One assertion per thing openclaw/src/mail-channel/inbound.ts depends on: BOTH
+        # imported functions and the policy field it passes. The field matters most -- it is
+        # an ordinary property, so an SDK without it drops the value silently and the
+        # authentication gate stops running with nothing raised anywhere.
+        #
+        # Searched across dist/ rather than pinned to channel-ingress-runtime.d.ts, because
+        # the types are re-exported through generated chunk files (measured: the field lives
+        # in a plugin-entry-*.d.ts chunk, not in the runtime module itself).
+        for sym in defineStableChannelIngressIdentity resolveChannelMessageIngress minIdentifierAuthentication; do
+          grep -rqF "$sym" "$DIST" 2>/dev/null || MISSING="$MISSING $sym"
+        done
 
         if [ -n "$MISSING" ]; then
           echo "available=false" >> "$GITHUB_OUTPUT"

--- a/.github/actions/openclaw-sdk-contract/action.yml
+++ b/.github/actions/openclaw-sdk-contract/action.yml
@@ -1,0 +1,114 @@
+name: OpenClaw SDK contract probe
+description: >-
+  Reports whether a PUBLISHED openclaw release satisfying this plugin's declared
+  floor actually ships the channel-ingress identifier-authentication contract the
+  mail channel calls. Asserts the capability, never a version string.
+
+outputs:
+  available:
+    description: "true when a published, installable SDK ships the contract"
+    value: ${{ steps.probe.outputs.available }}
+  version:
+    description: "Resolved SDK version that was probed; empty when the range resolves to nothing"
+    value: ${{ steps.probe.outputs.version }}
+  detail:
+    description: "One-line human-readable reason, suitable for a notice or an error"
+    value: ${{ steps.probe.outputs.detail }}
+
+runs:
+  using: composite
+  steps:
+    # Why a capability probe and not `if version >= 2026.8.1`:
+    #
+    # A version comparison is the same shape of check as the `npm view` verify step
+    # that passed on v3.14.0 while reading the PREVIOUS version off the registry. It
+    # reads like proof and is not. `2026.9.1-beta.1`, published 2026-08-28 and newer
+    # than the declared floor by every ordering, does NOT contain this contract, while
+    # openclaw `main` (package.json: 2026.8.1) does. Version order and capability are
+    # genuinely uncorrelated here, so the only honest question is whether the artifact
+    # npm would actually install exports what `mail-channel/inbound.ts` calls.
+    - id: probe
+      shell: bash
+      run: |
+        set -uo pipefail
+
+        FLOOR="$(node -p "require('./openclaw/package.json').peerDependencies.openclaw" 2>/dev/null || echo '')"
+        if [ -z "$FLOOR" ]; then
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          echo "version=" >> "$GITHUB_OUTPUT"
+          echo "detail=could not read peerDependencies.openclaw from openclaw/package.json" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "Declared floor: openclaw@$FLOOR"
+
+        # Highest published version satisfying the floor.
+        #
+        # `npm view --json` does NOT stay silent when a range matches nothing: it prints a
+        # JS-ish `{ error: { code: 'E404', ... } }` blob to STDOUT (measured), which is not
+        # valid JSON and is not a version. Parsing loosely here would hand that blob on as a
+        # "resolved version" and the probe would go on to fail for the wrong reason. So the
+        # result is accepted only when it looks like a version, and anything else means
+        # unresolved -- which is a legitimate answer, not an error.
+        RESOLVED="$(npm view "openclaw@$FLOOR" version --json 2>/dev/null \
+          | node -e "
+              let s='';
+              process.stdin.on('data', d => s += d);
+              process.stdin.on('end', () => {
+                let out = '';
+                try {
+                  const v = JSON.parse(s);
+                  const picked = Array.isArray(v) ? v[v.length - 1] : v;
+                  if (typeof picked === 'string') out = picked;
+                } catch { out = ''; }
+                console.log(/^[0-9][0-9A-Za-z.+-]*$/.test(out) ? out : '');
+              });
+            " 2>/dev/null || echo '')"
+
+        if [ -z "$RESOLVED" ]; then
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          echo "version=" >> "$GITHUB_OUTPUT"
+          echo "detail=no published openclaw release satisfies $FLOOR (npm resolves nothing; a >= range does not match prereleases)" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "Resolved: openclaw@$RESOLVED"
+
+        TARBALL="$(npm view "openclaw@$RESOLVED" dist.tarball 2>/dev/null | tr -d '[:space:]')"
+        if [ -z "$TARBALL" ]; then
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          echo "version=$RESOLVED" >> "$GITHUB_OUTPUT"
+          echo "detail=openclaw@$RESOLVED resolved but its tarball URL could not be read" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        WORK="$(mktemp -d)"
+        if ! curl -fsS "$TARBALL" -o "$WORK/sdk.tgz"; then
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          echo "version=$RESOLVED" >> "$GITHUB_OUTPUT"
+          echo "detail=could not download the openclaw@$RESOLVED tarball" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Three assertions, one per thing openclaw/src/mail-channel/inbound.ts depends on:
+        # the module it imports from, the function it calls, and the policy field it
+        # passes. The field matters most: it is an ordinary property, so an SDK without
+        # it drops the value silently and the authentication gate stops running with
+        # nothing raised anywhere.
+        MISSING=""
+        tar tzf "$WORK/sdk.tgz" 2>/dev/null | grep -q 'plugin-sdk/channel-ingress-runtime' \
+          || MISSING="$MISSING plugin-sdk/channel-ingress-runtime"
+        CONTENTS="$(tar xzOf "$WORK/sdk.tgz" 2>/dev/null || true)"
+        printf '%s' "$CONTENTS" | grep -q 'resolveChannelMessageIngress' \
+          || MISSING="$MISSING resolveChannelMessageIngress"
+        printf '%s' "$CONTENTS" | grep -q 'minIdentifierAuthentication' \
+          || MISSING="$MISSING minIdentifierAuthentication"
+
+        if [ -n "$MISSING" ]; then
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          echo "version=$RESOLVED" >> "$GITHUB_OUTPUT"
+          echo "detail=openclaw@$RESOLVED is missing:$MISSING" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "available=true" >> "$GITHUB_OUTPUT"
+        echo "version=$RESOLVED" >> "$GITHUB_OUTPUT"
+        echo "detail=openclaw@$RESOLVED ships the channel-ingress contract" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -9,9 +9,54 @@ permissions:
   contents: read
 
 jobs:
+  # Publishing is gated on the SDK actually shipping what the mail channel calls,
+  # because the three publish workflows fire independently on the same tag. Without
+  # this, a premature tag fails the two npm-installing workflows and SUCCEEDS on
+  # Homebrew, which builds the Swift CLI from the source tarball and never touches
+  # openclaw/. That leaves the tap pointing at a version npm and ClawHub never got,
+  # which is worse than nothing publishing at all.
+  preflight:
+    name: SDK contract preflight
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Probe the OpenClaw SDK contract
+        id: sdk
+        uses: ./.github/actions/openclaw-sdk-contract
+
+      - name: Refuse to publish against an SDK without the contract
+        if: steps.sdk.outputs.available != 'true'
+        env:
+          DETAIL: ${{ steps.sdk.outputs.detail }}
+        run: |
+          echo "::error::$DETAIL"
+          {
+            echo "### Publish blocked"
+            echo ""
+            echo "\`openclaw/src/mail-channel/inbound.ts\` calls the channel-ingress"
+            echo "identifier-authentication contract, and no installable SDK ships it yet."
+            echo ""
+            echo "> $DETAIL"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
+      - name: Report
+        if: steps.sdk.outputs.available == 'true'
+        env:
+          DETAIL: ${{ steps.sdk.outputs.detail }}
+        run: echo "::notice::$DETAIL"
+
   publish:
     name: Publish to ClawHub
     runs-on: ubuntu-latest
+    needs: preflight
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -16,9 +16,54 @@ permissions:
 # omarshahine/homebrew-tap with Contents: read & write. The default GITHUB_TOKEN
 # cannot push to a different repository.
 jobs:
+  # Publishing is gated on the SDK actually shipping what the mail channel calls,
+  # because the three publish workflows fire independently on the same tag. Without
+  # this, a premature tag fails the two npm-installing workflows and SUCCEEDS on
+  # Homebrew, which builds the Swift CLI from the source tarball and never touches
+  # openclaw/. That leaves the tap pointing at a version npm and ClawHub never got,
+  # which is worse than nothing publishing at all.
+  preflight:
+    name: SDK contract preflight
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Probe the OpenClaw SDK contract
+        id: sdk
+        uses: ./.github/actions/openclaw-sdk-contract
+
+      - name: Refuse to publish against an SDK without the contract
+        if: steps.sdk.outputs.available != 'true'
+        env:
+          DETAIL: ${{ steps.sdk.outputs.detail }}
+        run: |
+          echo "::error::$DETAIL"
+          {
+            echo "### Publish blocked"
+            echo ""
+            echo "\`openclaw/src/mail-channel/inbound.ts\` calls the channel-ingress"
+            echo "identifier-authentication contract, and no installable SDK ships it yet."
+            echo ""
+            echo "> $DETAIL"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
+      - name: Report
+        if: steps.sdk.outputs.available == 'true'
+        env:
+          DETAIL: ${{ steps.sdk.outputs.detail }}
+        run: echo "::notice::$DETAIL"
+
   bump:
     name: Bump apple-pim-cli formula
     runs-on: ubuntu-latest
+    needs: preflight
     env:
       TAP_REPO: omarshahine/homebrew-tap
       FORMULA_PATH: Formula/apple-pim-cli.rb

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,9 +10,54 @@ permissions:
   id-token: write
 
 jobs:
+  # Publishing is gated on the SDK actually shipping what the mail channel calls,
+  # because the three publish workflows fire independently on the same tag. Without
+  # this, a premature tag fails the two npm-installing workflows and SUCCEEDS on
+  # Homebrew, which builds the Swift CLI from the source tarball and never touches
+  # openclaw/. That leaves the tap pointing at a version npm and ClawHub never got,
+  # which is worse than nothing publishing at all.
+  preflight:
+    name: SDK contract preflight
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Probe the OpenClaw SDK contract
+        id: sdk
+        uses: ./.github/actions/openclaw-sdk-contract
+
+      - name: Refuse to publish against an SDK without the contract
+        if: steps.sdk.outputs.available != 'true'
+        env:
+          DETAIL: ${{ steps.sdk.outputs.detail }}
+        run: |
+          echo "::error::$DETAIL"
+          {
+            echo "### Publish blocked"
+            echo ""
+            echo "\`openclaw/src/mail-channel/inbound.ts\` calls the channel-ingress"
+            echo "identifier-authentication contract, and no installable SDK ships it yet."
+            echo ""
+            echo "> $DETAIL"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
+      - name: Report
+        if: steps.sdk.outputs.available == 'true'
+        env:
+          DETAIL: ${{ steps.sdk.outputs.detail }}
+        run: echo "::notice::$DETAIL"
+
   publish:
     name: Publish apple-pim-cli to NPM
     runs-on: ubuntu-latest
+    needs: preflight
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,73 @@ jobs:
       - name: Run Swift tests
         run: swift test
 
+  # openclaw/ defines `"test": "node --test \"src/**/*.test.ts\""` and, until now, nothing
+  # ran it. Those suites cover the mail channel's ingress admission -- allowlist matching,
+  # per-message authentication strength, the loop guard, thread permission, and the
+  # scenario table that exists to catch drift between the documented rows and the code.
+  # #121 rewrote all three of them under six green checks that never executed one.
+  #
+  # It cannot run for real yet: openclaw/package.json pins a floor no published release
+  # satisfies, so `npm install` here fails with ETARGET. Rather than land a red job or
+  # wait and forget, the job lands now and turns itself on the moment an installable SDK
+  # ships the contract. While it cannot run it says so in the step summary and in a
+  # notice, because a job that goes quietly green is the failure mode this repo keeps
+  # finding (see the v3.14.0 publish "Verify" step, and this suite's own absence).
+  #
+  # Do NOT make this a required check until the summary stops saying "skipped".
+  openclaw-plugin-tests:
+    name: OpenClaw Plugin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          # `node --test` runs .ts directly via type stripping on 22+.
+          node-version: 24
+
+      - name: Probe the OpenClaw SDK contract
+        id: sdk
+        uses: ./.github/actions/openclaw-sdk-contract
+
+      - name: Skip, loudly, while no installable SDK ships the contract
+        if: steps.sdk.outputs.available != 'true'
+        env:
+          DETAIL: ${{ steps.sdk.outputs.detail }}
+        run: |
+          echo "::notice::openclaw tests skipped -- $DETAIL"
+          {
+            echo "### OpenClaw plugin tests: SKIPPED"
+            echo ""
+            echo "> $DETAIL"
+            echo ""
+            echo "This job proves nothing in this run. It starts running by itself once a"
+            echo "published SDK ships the channel-ingress contract."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Install root dependencies
+        if: steps.sdk.outputs.available == 'true'
+        run: npm install
+
+      - name: Install plugin dependencies
+        if: steps.sdk.outputs.available == 'true'
+        working-directory: openclaw
+        run: npm install
+
+      - name: Run OpenClaw plugin tests
+        if: steps.sdk.outputs.available == 'true'
+        working-directory: openclaw
+        run: npm test
+
+      - name: Record that the suite actually ran
+        if: steps.sdk.outputs.available == 'true'
+        env:
+          VERSION: ${{ steps.sdk.outputs.version }}
+        run: |
+          echo "### OpenClaw plugin tests: RAN against openclaw@$VERSION" >> "$GITHUB_STEP_SUMMARY"
+
   version-check:
     name: Version Consistency
     runs-on: ubuntu-latest


### PR DESCRIPTION
Two gaps with one cause: nothing checked that the SDK the mail channel calls is actually installable, and nothing ran the tests that would have noticed.

## Publishing is gated on a capability, not a version string

The three publish workflows fire independently on the same tag, and only two install from npm. A tag pushed today would:

| Workflow | Outcome |
| --- | --- |
| Publish to NPM | fails at `npm install` (`ETARGET`, `openclaw@>=2026.8.1` unresolvable) |
| Publish to ClawHub | fails the same way |
| Publish to Homebrew Tap | **succeeds** — builds the Swift CLI from the source tarball, never touches `openclaw/` |

That leaves the tap pointing at a version npm and ClawHub never got, which is worse than nothing publishing. All three now `needs:` a `preflight` job that refuses the tag.

## Why a probe and not `if version >= 2026.8.1`

A version comparison is the same shape of check as the `npm view` verify step that passed on v3.14.0 while reading the *previous* version off the registry. It reads like proof and isn't.

Here it would also be wrong on the facts:

| Published build | Date | Ships the contract |
| --- | --- | --- |
| `2026.7.1-2` (latest) | — | no |
| `2026.8.1-beta.3` | Aug 24 | no |
| `2026.9.1-beta.1` | **Aug 28** | **no** |
| openclaw `main` (package.json `2026.8.1`) | Aug 27, #123782 | **yes** |

`2026.9.1-beta.1` is newer than the declared floor by every ordering and does not carry the contract. Version order and capability are genuinely uncorrelated, so the probe asks the only honest question: does the artifact npm would resolve export what `mail-channel/inbound.ts` calls?

Three assertions, one per dependency in that file: the `plugin-sdk/channel-ingress-runtime` module path, `resolveChannelMessageIngress`, and the `minIdentifierAuthentication` policy field. The last matters most — it is an ordinary property, so an SDK without it drops the value silently and the authentication gate stops running with nothing raised anywhere.

## One npm sharp edge worth knowing

`npm view --json` does **not** stay quiet when a range matches nothing. It prints a JS-ish blob to **stdout**:

```
{ error: { code: 'E404', summary: 'No match found for version >=2026.8.1', ... } }
```

which is neither valid JSON nor a version. My first cut parsed loosely and carried that blob forward as a "resolved version," which would have failed the probe for the wrong reason. Resolution now accepts a result only when it looks like a version; anything else means unresolved, which is a legitimate answer rather than an error.

Verified both directions locally:

```
range >=2026.8.1  → resolved ''         → available=false   ✓ (today's real state)
range >=2026.7.0  → resolved '2026.7.1' → parses cleanly     ✓
  └ and that build is correctly reported as missing the contract
```

## OpenClaw Plugin test job (#122)

`openclaw/package.json` has defined `"test": "node --test \"src/**/*.test.ts\""` all along and CI never called it. Those suites cover the mail channel's ingress admission, thread permission, and the scenario table that exists to catch drift between the documented rows and the code — and #121 rewrote all three under six green checks that executed none of them.

It cannot run for real until the SDK ships, so it lands gated on the same probe and turns itself on. While skipped it says so in a `::notice::` and in the step summary rather than going quietly green, since a check that passes without proving anything is the exact failure mode this repo keeps finding.

**Do not mark it required until the step summary stops saying `SKIPPED`.**

## Notes

- `actionlint` is clean on everything here. It reports one pre-existing SC2129 style note on `publish-homebrew.yml`'s `Resolve version and tarball checksum` step, which is untouched by this PR.
- No version bump: this is CI only.