### PR TITLE
Fix Apple Mail channel agent dispatch

### DIFF
--- a/lib/fields.js
+++ b/lib/fields.js
@@ -14,6 +14,7 @@ const WRAPPER_KEYS = new Set([
   "reminders",
   "contacts",
   "messages",
+  "message",
   "calendars",
   "lists",
   "groups",

--- a/lib/fields.js
+++ b/lib/fields.js
@@ -80,6 +80,11 @@ export function applyFieldSelection(result, fields) {
     if (WRAPPER_KEYS.has(key) && Array.isArray(value)) {
       // Filter each item in the wrapped array
       filtered[key] = value.map((item) => pickFields(item, fields));
+    } else if (key === "message" && value && typeof value === "object") {
+      // A single-message response is structurally identical to a messages array with one
+      // item. Preserve the wrapper, but still apply the caller's token-reduction request to
+      // its contents.
+      filtered[key] = pickFields(value, fields);
     } else if (WRAPPER_KEYS.has(key)) {
       // Structural scalars/objects (e.g., success, status) — keep as-is
       filtered[key] = value;

--- a/openclaw/src/fields.test.ts
+++ b/openclaw/src/fields.test.ts
@@ -1,0 +1,20 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { applyFieldSelection } from "../lib/fields.js";
+
+describe("mail field selection", () => {
+  it("preserves a single message wrapper", () => {
+    const result = applyFieldSelection(
+      {
+        success: true,
+        message: { id: "m1", sender: "omar@example.com", content: "hello", source: "raw" },
+      },
+      ["sender", "content"],
+    );
+
+    assert.deepEqual(result, {
+      success: true,
+      message: { id: "m1", sender: "omar@example.com", content: "hello", source: "raw" },
+    });
+  });
+});

--- a/openclaw/src/fields.test.ts
+++ b/openclaw/src/fields.test.ts
@@ -14,7 +14,7 @@ describe("mail field selection", () => {
 
     assert.deepEqual(result, {
       success: true,
-      message: { id: "m1", sender: "omar@example.com", content: "hello", source: "raw" },
+      message: { id: "m1", sender: "omar@example.com", content: "hello" },
     });
   });
 });

--- a/openclaw/src/mail-channel/dispatch.test.ts
+++ b/openclaw/src/mail-channel/dispatch.test.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 
 const OPTIONS: DispatchOptions = {
   cfg: {} as OpenClawConfig,
+  agentId: "lobster",
   operatorAddresses: ["operator@example.com"],
   egressAllowlist: ["known@example.com"],
   selfAddresses: ["lobster@example.com"],
@@ -180,9 +181,11 @@ describe("dispatchAdmittedMessage", () => {
   // conversations; a thread has a natural start and finish.
   it("scopes the session per thread", async () => {
     const keys: (string | undefined)[] = [];
+    const agentIds: (string | undefined)[] = [];
     const { deps: d } = deps({
       dispatchReply: async ({ ctx }) => {
         keys.push(ctx.SessionKey);
+        agentIds.push(ctx.AgentId);
       },
     });
     const first = classified("operator@example.com");
@@ -197,10 +200,11 @@ describe("dispatchAdmittedMessage", () => {
       await dispatchAdmittedMessage(m, d, OPTIONS);
     }
     assert.deepEqual(keys, [
-      "apple-mail:default:m1",
-      "apple-mail:default:m1",
-      "apple-mail:default:m3",
+      "agent:lobster:apple-mail:default:m1",
+      "agent:lobster:apple-mail:default:m1",
+      "agent:lobster:apple-mail:default:m3",
     ]);
+    assert.deepEqual(agentIds, ["lobster", "lobster", "lobster"]);
   });
 
   it("keeps two senders in one thread together, since no thread spans strangers", async () => {
@@ -215,7 +219,10 @@ describe("dispatchAdmittedMessage", () => {
     b.threadKey = "m1";
     await dispatchAdmittedMessage(a, d, OPTIONS);
     await dispatchAdmittedMessage(b, d, OPTIONS);
-    assert.deepEqual(keys, ["apple-mail:default:m1", "apple-mail:default:m1"]);
+    assert.deepEqual(keys, [
+      "agent:lobster:apple-mail:default:m1",
+      "agent:lobster:apple-mail:default:m1",
+    ]);
   });
 });
 

--- a/openclaw/src/mail-channel/dispatch.ts
+++ b/openclaw/src/mail-channel/dispatch.ts
@@ -39,7 +39,7 @@ export type ReplySender = (params: {
  * reached through `ctx.channelRuntime`, whose surface is `{ [key: string]: unknown }`.
  */
 export type ReplyDispatcher = (params: {
-  ctx: { Body?: string; From?: string; To?: string; SessionKey?: string };
+  ctx: { Body?: string; From?: string; To?: string; SessionKey?: string; AgentId?: string };
   cfg: OpenClawConfig;
   // `deliver` must return a promise: the SDK awaits it to know when a block settled.
   dispatcherOptions: { deliver: (payload: { text?: string }) => Promise<unknown> };
@@ -73,6 +73,8 @@ export type DispatchDeps = {
 
 export type DispatchOptions = {
   cfg: OpenClawConfig;
+  /** Agent selected by the channel binding. Required when more than one agent exists. */
+  agentId: string;
   /** Addresses belonging to the operator. Always a permitted reply recipient. */
   operatorAddresses: readonly string[];
   /** Recipients the agent may originate mail to. */
@@ -131,7 +133,9 @@ function buildPrompt(message: MailboxMessage, summary: string | undefined): stri
   parts.push(
     "The body was deliberately not fetched, because most admitted mail is never worth " +
       "opening. When answering needs it, call `apple_pim_mail` with `action: \"get\"` and " +
-      "`id` set to the Message-ID above, then answer what the message actually asks.\n\n" +
+      "`id` set to the Message-ID above, then answer what the message actually asks. " +
+      "Do not call the mail tool's `send` or `reply` actions. Channel delivery owns the " +
+      "outbound reply and will send your final text exactly once.\n\n" +
       "Your reply is sent to the sender verbatim as the email body, so write the message " +
       "itself: no preamble, no restating the subject, no narrating that mail arrived.",
   );
@@ -191,7 +195,8 @@ export async function dispatchAdmittedMessage(
       // and finish. `threadKey` is the anchor the agent recorded for this thread, so every
       // message in it lands in the same session, and correspondents still cannot read each
       // other because no thread spans two of them.
-      SessionKey: `${options.sessionPrefix}:${message.threadKey}`,
+      SessionKey: `agent:${options.agentId}:${options.sessionPrefix}:${message.threadKey}`,
+      AgentId: options.agentId,
     },
     cfg: options.cfg,
     dispatcherOptions: {

--- a/openclaw/src/mail-channel/entry.ts
+++ b/openclaw/src/mail-channel/entry.ts
@@ -35,6 +35,7 @@ import {
 } from "../../lib/mail-quarantine.js";
 import { dispatchAdmittedMessage } from "./dispatch.ts";
 import { dispatchReplyWithBufferedBlockDispatcher } from "openclaw/plugin-sdk/reply-dispatch-runtime";
+import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import {
   channelBlockedPatch,
   channelReadyPatch,
@@ -334,6 +335,12 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
               completed += 1;
               continue;
             }
+            const route = resolveAgentRoute({
+              cfg: ctx.cfg,
+              channel: CHANNEL_ID,
+              accountId: ctx.accountId,
+              peer: { kind: "direct", id: message.address },
+            });
             await dispatchAdmittedMessage(
               message,
               {
@@ -359,6 +366,7 @@ const gateway: NonNullable<ChannelPlugin<ResolvedAppleMailAccount>["gateway"]> =
               },
               {
                 cfg: ctx.cfg,
+                agentId: route.agentId,
                 operatorAddresses: config.operatorAddresses ?? [],
                 egressAllowlist: config.egressAllowlist ?? [],
                 selfAddresses: config.selfAddresses ?? [],

--- a/openclaw/src/mail-channel/runtime.test.ts
+++ b/openclaw/src/mail-channel/runtime.test.ts
@@ -3,7 +3,7 @@
 // ourselves means owning that too.
 import { describe, it } from "node:test";
 import { strict as assert } from "node:assert";
-import { replySubject } from "./runtime.ts";
+import { replySubject, replyTransportArgs } from "./runtime.ts";
 
 describe("replySubject", () => {
   it("prefixes a plain subject", () => {
@@ -26,5 +26,23 @@ describe("replySubject", () => {
 
   it("trims surrounding whitespace rather than embedding it", () => {
     assert.equal(replySubject("  Testing  "), "Re: Testing");
+  });
+});
+
+describe("replyTransportArgs", () => {
+  it("uses network-safe submission defaults for iCloud identities", () => {
+    assert.deepEqual(replyTransportArgs("agent@icloud.com"), [
+      "--tls-mode",
+      "starttls",
+      "--port",
+      "587",
+      "--no-imap-append-sent",
+    ]);
+    assert.deepEqual(replyTransportArgs("agent@ME.com"), replyTransportArgs("agent@icloud.com"));
+  });
+
+  it("does not override a custom SMTP transport", () => {
+    assert.deepEqual(replyTransportArgs("agent@example.com"), []);
+    assert.deepEqual(replyTransportArgs(undefined), []);
   });
 });

--- a/openclaw/src/mail-channel/runtime.ts
+++ b/openclaw/src/mail-channel/runtime.ts
@@ -202,6 +202,18 @@ export function replySubject(subject: string | undefined): string {
 }
 
 /**
+ * Network-safe iCloud defaults for installations that use the CLI's implicit iCloud host.
+ * Other senders keep their configured SMTP transport untouched.
+ */
+export function replyTransportArgs(fromAddress: string | undefined): string[] {
+  const domain = fromAddress?.split("@").at(-1)?.trim().toLowerCase();
+  if (!domain || !["icloud.com", "me.com", "mac.com"].includes(domain)) {
+    return [];
+  }
+  return ["--tls-mode", "starttls", "--port", "587", "--no-imap-append-sent"];
+}
+
+/**
  * Sends a reply through `mail-cli smtp-send`.
  *
  * Deliberately not `mail-cli reply`, which drives Mail.app over JXA. That path asks Mail to
@@ -231,15 +243,10 @@ export function createMailCliSender(options: MailCliOptions): ReplySender {
       replySubject(subject),
       "--body",
       body,
-      // Port 465 is blocked on some otherwise-supported networks. The Swift transport
-      // supports STARTTLS natively, and iCloud exposes it on 587.
-      "--tls-mode",
-      "starttls",
-      "--port",
-      "587",
-      // Delivery completion must not depend on a second IMAP connection. The channel keeps
-      // its own durable thread record using the SMTP Message-ID returned below.
-      "--no-imap-append-sent",
+      // Port 465 is blocked on some otherwise-supported networks. Apply the known-good
+      // iCloud submission path only to iCloud identities; custom SMTP senders must retain
+      // the host, port, TLS, and Sent-folder behavior from their own configuration.
+      ...replyTransportArgs(options.fromAddress),
       // Threads the reply onto the original. `smtp-send` derives `References` from this when
       // none is passed, which is correct for answering a message directly.
       "--in-reply-to",

--- a/openclaw/src/mail-channel/runtime.ts
+++ b/openclaw/src/mail-channel/runtime.ts
@@ -231,6 +231,15 @@ export function createMailCliSender(options: MailCliOptions): ReplySender {
       replySubject(subject),
       "--body",
       body,
+      // Port 465 is blocked on some otherwise-supported networks. The Swift transport
+      // supports STARTTLS natively, and iCloud exposes it on 587.
+      "--tls-mode",
+      "starttls",
+      "--port",
+      "587",
+      // Delivery completion must not depend on a second IMAP connection. The channel keeps
+      // its own durable thread record using the SMTP Message-ID returned below.
+      "--no-imap-append-sent",
       // Threads the reply onto the original. `smtp-send` derives `References` from this when
       // none is passed, which is correct for answering a message directly.
       "--in-reply-to",


### PR DESCRIPTION
## Summary

- resolve the configured OpenClaw agent binding before dispatching an inbound email
- use an agent-owned, thread-scoped session key and pass the resolved agent ID to the dispatcher
- preserve the single-message response wrapper so the agent can read fetched mail content
- keep reply delivery channel-owned and use reliable iCloud STARTTLS submission defaults

## Verification

- `node --test src/mail-channel/dispatch.test.ts src/fields.test.ts` (17 passing)
- `npm run build`
- live arrival proof: an authenticated message from the operator was dispatched to the Lobster agent, read, and answered once; the receiving mailbox confirmed the reply

## Existing test state

The broader `npm test` run currently has eight pre-existing ingress-policy expectation failures against the installed OpenClaw SDK semantics. The failures are outside the changed routing, field-selection, and delivery paths; the focused regression suites above pass.
