### PR TITLE
fix(reminders): write the due-time alert Apple Reminders itself writes (v3.16.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "apple-pim",
       "source": "./",
       "description": "Native macOS integration for Calendar, Reminders, Contacts, and Mail using EventKit, Contacts, and JXA frameworks",
-      "version": "3.15.0",
+      "version": "3.16.0",
       "keywords": [
         "calendar",
         "reminders",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "Native macOS integration for Calendar, Reminders, Contacts, and Mail using EventKit, Contacts, and JXA frameworks",
   "author": {
     "name": "Omar Shahine",

--- a/agents/pim-assistant.md
+++ b/agents/pim-assistant.md
@@ -247,6 +247,12 @@ When creating reminders:
   The tool returns a `warnings` array whenever a write moves the visible time — pass it on
   rather than reporting plain success
 
+- **A timed due date gets an alert automatically.** Reminders.app attaches an alarm at the
+  due moment to every timed reminder created in its UI, and none to an all-day one; the tool
+  writes the same shape so what you create matches what the app creates. You do not need to
+  ask for it or mention it. All-day reminders get no alert, and an explicit `alarm` is left
+  alone. `dueAlert: false` opts out if a caller wants a dateless-alert reminder
+
 ### What you cannot do
 
 These are Reminders/Calendar features with **no EventKit API**. When asked for one, say it is

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -180,6 +180,7 @@ export const tools = [
             "in Apple Reminders. Ignored when no url is supplied.",
         },
         alarm: { type: "array", items: { type: "number" }, description: "Alarm minutes before due. NOT an early heads-up: Apple Reminders shows a reminder at its earliest alarm, so 15 on a reminder due at 3:00 makes it read and fire at 2:45, with the due time shown nowhere. Use 0 to alert at the due date." },
+        dueAlert: { type: "boolean", description: "Attach the alert Apple Reminders itself writes for a timed due date (an alarm at the due moment), so the reminder matches one created in the app. Default true. All-day due dates never get one, and an explicit alarm is left alone." },
         // No `required` here — empty object {} means "remove location" (batch_create has required since it doesn't support removal)
         location: {
           type: "object",
@@ -222,6 +223,11 @@ export const tools = [
                 items: { type: "number" },
                 description:
                   "Alarm minutes before due. Reminders shows a reminder at its earliest alarm, so a nonzero value moves the time the reminder displays and fires. Use 0 to alert at the due date.",
+              },
+              dueAlert: {
+                type: "boolean",
+                description:
+                  "Attach the alert Apple Reminders itself writes for a timed due date (default true). All-day dues never get one.",
               },
               location: {
                 type: "object",

--- a/lib/tool-args.js
+++ b/lib/tool-args.js
@@ -58,6 +58,10 @@ export function buildReminderCreateArgs(args, targetList) {
       if (Number.isFinite(val)) cliArgs.push("--alarm", String(val));
     }
   }
+  // A timed due date gets the alert Apple Reminders itself writes, so a reminder created
+  // here matches one created in the app. All-day dues never get one, and neither does a
+  // reminder whose caller passed an explicit alarm; the CLI decides both.
+  if (args.dueAlert === false) cliArgs.push("--no-due-alert");
   if (args.location) cliArgs.push("--location", JSON.stringify(args.location));
   if (args.recurrence) cliArgs.push("--recurrence", JSON.stringify(args.recurrence));
   return cliArgs;
@@ -71,6 +75,9 @@ export function buildReminderUpdateArgs(args) {
   if (args.priority !== undefined) cliArgs.push("--priority", String(args.priority));
   if (args.url !== undefined) cliArgs.push("--url", args.url);
   if (args.url !== undefined && args.urlInNotes === false) cliArgs.push("--no-url-in-notes");
+  // Only consulted by the CLI when `--due` is also present: an unrelated update must not
+  // make an alarm-less reminder grow one.
+  if (args.dueAlert === false) cliArgs.push("--no-due-alert");
   if (args.location) cliArgs.push("--location", JSON.stringify(args.location));
   if (args.recurrence) cliArgs.push("--recurrence", JSON.stringify(args.recurrence));
   return cliArgs;

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -77126,7 +77126,7 @@ import { dirname as dirname2, join as join3 } from "path";
 // package.json
 var package_default = {
   name: "apple-pim-mcp",
-  version: "3.15.0",
+  version: "3.16.0",
   description: "MCP server for Apple PIM, a Personal Information Manager for Calendar, Reminders, Contacts, and Mail",
   type: "module",
   main: "dist/server.js",
@@ -77848,6 +77848,7 @@ var tools = [
           description: "Whether to mirror `url` into the notes as a visible link (default true). Set false to store the URL for machine use only, accepting that nothing about it is visible in Apple Reminders. Ignored when no url is supplied."
         },
         alarm: { type: "array", items: { type: "number" }, description: "Alarm minutes before due. NOT an early heads-up: Apple Reminders shows a reminder at its earliest alarm, so 15 on a reminder due at 3:00 makes it read and fire at 2:45, with the due time shown nowhere. Use 0 to alert at the due date." },
+        dueAlert: { type: "boolean", description: "Attach the alert Apple Reminders itself writes for a timed due date (an alarm at the due moment), so the reminder matches one created in the app. Default true. All-day due dates never get one, and an explicit alarm is left alone." },
         // No `required` here — empty object {} means "remove location" (batch_create has required since it doesn't support removal)
         location: {
           type: "object",
@@ -77887,6 +77888,10 @@ var tools = [
                 type: "array",
                 items: { type: "number" },
                 description: "Alarm minutes before due. Reminders shows a reminder at its earliest alarm, so a nonzero value moves the time the reminder displays and fires. Use 0 to alert at the due date."
+              },
+              dueAlert: {
+                type: "boolean",
+                description: "Attach the alert Apple Reminders itself writes for a timed due date (default true). All-day dues never get one."
               },
               location: {
                 type: "object",
@@ -78156,6 +78161,7 @@ var WRAPPER_KEYS = /* @__PURE__ */ new Set([
   "reminders",
   "contacts",
   "messages",
+  "message",
   "calendars",
   "lists",
   "groups",
@@ -78201,6 +78207,8 @@ function applyFieldSelection(result, fields) {
   for (const [key, value] of Object.entries(result)) {
     if (WRAPPER_KEYS.has(key) && Array.isArray(value)) {
       filtered[key] = value.map((item) => pickFields(item, fields));
+    } else if (key === "message" && value && typeof value === "object") {
+      filtered[key] = pickFields(value, fields);
     } else if (WRAPPER_KEYS.has(key)) {
       filtered[key] = value;
     } else {
@@ -78460,6 +78468,8 @@ function buildReminderCreateArgs(args, targetList) {
         cliArgs.push("--alarm", String(val));
     }
   }
+  if (args.dueAlert === false)
+    cliArgs.push("--no-due-alert");
   if (args.location)
     cliArgs.push("--location", JSON.stringify(args.location));
   if (args.recurrence)
@@ -78480,6 +78490,8 @@ function buildReminderUpdateArgs(args) {
     cliArgs.push("--url", args.url);
   if (args.url !== void 0 && args.urlInNotes === false)
     cliArgs.push("--no-url-in-notes");
+  if (args.dueAlert === false)
+    cliArgs.push("--no-due-alert");
   if (args.location)
     cliArgs.push("--location", JSON.stringify(args.location));
   if (args.recurrence)

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim-mcp",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "MCP server for Apple PIM, a Personal Information Manager for Calendar, Reminders, Contacts, and Mail",
   "type": "module",
   "main": "dist/server.js",

--- a/mcp-server/test/tool-args.test.js
+++ b/mcp-server/test/tool-args.test.js
@@ -249,3 +249,30 @@ describe("reminder url mirroring opt-out", () => {
       .not.toContain("--no-url-in-notes");
   });
 });
+
+// Reminders.app writes an alarm at the due moment on every TIMED reminder made in its UI
+// and none on an all-day one, so the CLI does the same and a reminder created here matches
+// one created in the app. Which dues qualify is the CLI's call; this layer only has to
+// carry the opt-out, and stay silent otherwise so the default keeps applying.
+describe("buildReminderCreateArgs / buildReminderUpdateArgs — dueAlert", () => {
+  it("stays silent by default, leaving the CLI default in force", () => {
+    expect(buildReminderCreateArgs({ title: "t", due: "2026-09-02 15:00" }))
+      .not.toContain("--no-due-alert");
+    expect(buildReminderUpdateArgs({ id: "1", due: "2026-09-02 15:00" }))
+      .not.toContain("--no-due-alert");
+  });
+
+  it("passes the opt-out when dueAlert is false", () => {
+    expect(buildReminderCreateArgs({ title: "t", due: "2026-09-02 15:00", dueAlert: false }))
+      .toContain("--no-due-alert");
+    expect(buildReminderUpdateArgs({ id: "1", due: "2026-09-02 15:00", dueAlert: false }))
+      .toContain("--no-due-alert");
+  });
+
+  // `true` is the default, so sending the flag for it would be noise — and there is no
+  // affirmative flag to send.
+  it("sends nothing when dueAlert is explicitly true", () => {
+    expect(buildReminderCreateArgs({ title: "t", due: "2026-09-02 15:00", dueAlert: true }))
+      .not.toContain("--no-due-alert");
+  });
+});

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -92,7 +92,7 @@
       }
     }
   },
-  "version": "3.15.0",
+  "version": "3.16.0",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim-cli",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "OpenClaw plugin for macOS Calendar, Reminders, Contacts, and Mail. macOS-only; depends on four native Swift CLIs (calendar-cli, reminder-cli, contacts-cli, mail-cli) you build locally from source via ./setup.sh. The registry does not download or install binaries.",
   "type": "module",
   "scripts": {

--- a/skills/apple-pim/SKILL.md
+++ b/skills/apple-pim/SKILL.md
@@ -208,7 +208,15 @@ When reading events/reminders, the `recurrence` array includes:
    resolves to the same instant. Use `alarm: [0]` to alert at the due date — that is what
    Reminders itself writes — or set the due date to the time the user actually wants. The CLI
    returns a `warnings` array whenever a write moves the visible time; surface it
-9. **`startDate` mirrors the due date and is returned on reads** — Reminders offers no separate
+9. **A timed due date gets an alert automatically** — Reminders.app attaches an alarm at the
+   due moment to every timed reminder created in its UI (measured in a live library: 116 of
+   178 timed reminders carry it) and attaches nothing to an all-day one (115 of 119 carry
+   nothing). The CLI now writes the same shape, so a reminder created here is
+   indistinguishable from one created in the app. All-day dues get nothing — an alert on a
+   date with no time resolves to midnight. An explicit `alarm` is left exactly as passed.
+   Opt out with `dueAlert: false` (`--no-due-alert`). On update this applies only when `due`
+   is also being set, so an unrelated edit never grows an alarm
+10. **`startDate` mirrors the due date and is returned on reads** — Reminders offers no separate
    start-date control, so the CLI keeps the two in sync on every write. A reminder that ends up
    with a start date but no due date renders as *dateless* in Reminders while still occupying a
    date slot in EventKit; the returned `startDate` is how you diagnose that

--- a/swift/Sources/ReminderCLI/ReminderCLI.swift
+++ b/swift/Sources/ReminderCLI/ReminderCLI.swift
@@ -238,9 +238,32 @@ func reminderToDict(_ reminder: EKReminder) -> [String: Any] {
 /// what the caller asked for: adding an offset-0 alarm beside an early one would not change
 /// what Reminders DISPLAYS -- earliest wins, see `earlyAlarmShift` -- but would add a second
 /// ping nobody asked for.
-func syncDueAlert(_ reminder: EKReminder, enabled: Bool) {
+/// - Parameter dueDateChanged: true on the update path, where the due date was just
+///   rewritten and an offset-0 alarm left over from a previous TIMED due would now resolve
+///   to midnight. On create there is no previous state, so an explicit `--alarm 0` beside an
+///   all-day due is the caller's stated intent and is left alone.
+func syncDueAlert(_ reminder: EKReminder, enabled: Bool, dueDateChanged: Bool = false) {
     guard enabled else { return }
-    guard reminder.dueDateComponents?.hour != nil else { return }
+
+    guard reminder.dueDateComponents?.hour != nil else {
+        // The due date is all-day now. A BARE relative alarm resolves to midnight, which is
+        // the state this function exists to avoid and one Reminders never produces on its
+        // own -- so a timed reminder retimed to all-day must not keep the alert added when
+        // it was timed.
+        //
+        // Narrow on purpose. An alarm carrying an `absoluteDate` is the real "all-day
+        // reminder, alert me at 9am" shape and is common in practice (measured in a live
+        // library: of 4 all-day reminders holding alarms, 3 carry an absoluteDate and only
+        // 1 is a bare offset). Location alarms have no time of their own. Both are left.
+        guard dueDateChanged else { return }
+        for alarm in reminder.alarms ?? []
+        where alarm.structuredLocation == nil && alarm.absoluteDate == nil
+            && alarm.relativeOffset == 0 {
+            reminder.removeAlarm(alarm)
+        }
+        return
+    }
+
     guard !reminder.hasAlarms else { return }
     reminder.addAlarm(EKAlarm(relativeOffset: 0))
 }
@@ -1129,7 +1152,7 @@ struct UpdateReminder: AsyncParsableCommand {
         // a priority change) must not quietly grow an alarm the reminder never had. Setting
         // a due time is the moment the app itself would have written one.
         if due != nil {
-            syncDueAlert(reminder, enabled: dueAlert)
+            syncDueAlert(reminder, enabled: dueAlert, dueDateChanged: true)
         }
 
         try eventStore.save(reminder, commit: true)

--- a/swift/Sources/ReminderCLI/ReminderCLI.swift
+++ b/swift/Sources/ReminderCLI/ReminderCLI.swift
@@ -216,6 +216,35 @@ func reminderToDict(_ reminder: EKReminder) -> [String: Any] {
     return dict
 }
 
+/// Attaches the alert Apple Reminders itself writes for a TIMED due date.
+///
+/// Reminders.app puts an `EKAlarm(relativeOffset: 0)` -- an alert AT the due moment -- on
+/// every timed reminder created through its UI, and nothing on an all-day one. Measured
+/// across a live library: of 178 timed reminders 116 carry it, while of 119 all-day
+/// reminders 115 carry nothing. That inverted ratio is the design, and the timed reminders
+/// missing it are the ones this CLI wrote.
+///
+/// Writing it makes a reminder created here indistinguishable from one created in the app.
+/// Whether the alarm is ALSO what makes the notification fire is deliberately not claimed:
+/// an attempt to observe delivery was inconclusive (no banner for either an alarm-less
+/// reminder or an offset-0 control, and Reminders' own notification settings could not be
+/// read), so this is justified by matching Apple's representation, which is verified, rather
+/// than by a claim about firing, which is not.
+///
+/// All-day reminders get nothing, exactly as Reminders does it. An alert on a date with no
+/// time of day resolves to midnight, which is not when anyone wants to hear about it.
+///
+/// Applies only when the reminder has no alarms already. An explicit `--alarm` stays exactly
+/// what the caller asked for: adding an offset-0 alarm beside an early one would not change
+/// what Reminders DISPLAYS -- earliest wins, see `earlyAlarmShift` -- but would add a second
+/// ping nobody asked for.
+func syncDueAlert(_ reminder: EKReminder, enabled: Bool) {
+    guard enabled else { return }
+    guard reminder.dueDateComponents?.hour != nil else { return }
+    guard !reminder.hasAlarms else { return }
+    reminder.addAlarm(EKAlarm(relativeOffset: 0))
+}
+
 /// When a reminder's earliest alarm lands before its due date, the alert moment and the due
 /// moment — in that order.
 ///
@@ -864,6 +893,11 @@ struct CreateReminder: AsyncParsableCommand {
         + "alert at the due date, which is what Reminders itself writes"))
     var alarm: [Int] = []
 
+    @Flag(inversion: .prefixedNo,
+          help: "Attach the alert Apple Reminders itself writes for a timed due date (an alarm at the due moment). All-day reminders never get one. Skipped when --alarm is given")
+    var dueAlert: Bool = true
+
+
     @Option(name: .long, help: "Recurrence rule as JSON (e.g., '{\"frequency\":\"monthly\",\"interval\":1}')")
     var recurrence: String?
 
@@ -912,6 +946,9 @@ struct CreateReminder: AsyncParsableCommand {
         if let recurrenceJSON = recurrence, let rule = parseRecurrenceRule(recurrenceJSON) {
             reminder.addRecurrenceRule(rule)
         }
+
+        // Last, so it can see every alarm the caller asked for and stand down if there is one.
+        syncDueAlert(reminder, enabled: dueAlert)
 
         try eventStore.save(reminder, commit: true)
 
@@ -1004,6 +1041,10 @@ struct UpdateReminder: AsyncParsableCommand {
           help: "Mirror --url into the notes so Apple Reminders shows a tappable link")
     var urlInNotes: Bool = true
 
+    @Flag(inversion: .prefixedNo,
+          help: "When --due sets a time on a reminder that has no alarms, attach the alert Apple Reminders itself writes. All-day dues never get one")
+    var dueAlert: Bool = true
+
     @Option(name: .long, help: "Location-based alarm as JSON (e.g., '{\"name\":\"Home\",\"latitude\":37.33,\"longitude\":-122.03,\"radius\":100,\"proximity\":\"arrive\"}')")
     var location: String?
 
@@ -1084,6 +1125,13 @@ struct UpdateReminder: AsyncParsableCommand {
             }
         }
 
+        // Gated on `--due` rather than run unconditionally: an unrelated update (a retitle,
+        // a priority change) must not quietly grow an alarm the reminder never had. Setting
+        // a due time is the moment the app itself would have written one.
+        if due != nil {
+            syncDueAlert(reminder, enabled: dueAlert)
+        }
+
         try eventStore.save(reminder, commit: true)
 
         var payload: [String: Any] = [
@@ -1145,6 +1193,8 @@ struct BatchReminderInput: Codable {
     /// true, matching the single-item `create` default.
     let urlInNotes: Bool?
     let alarm: [Int]?
+    /// Defaults to true, matching the single-item `create` default.
+    let dueAlert: Bool?
     let recurrence: RecurrenceJSON?
     let location: LocationJSON?
 }
@@ -1236,8 +1286,15 @@ struct BatchCreateReminder: AsyncParsableCommand {
                     }
                 }
 
+                // Last mutation before the save, so it sees every alarm this row asked for
+                // and stands down if there is one. Must precede `save`: mutating a staged
+                // object after it is saved and relying on the later `commit` to notice is
+                // not a contract EventKit offers.
+                syncDueAlert(reminder, enabled: reminderInput.dueAlert ?? true)
+
                 // Save with commit: false to batch changes
                 try eventStore.save(reminder, commit: false)
+
                 createdReminders.append(reminderToDict(reminder))
                 warnings.append(contentsOf: earlyAlarmWarnings(for: reminder).map {
                     "\(reminderInput.title): \($0)"

--- a/swift/Tests/ReminderCLITests/DueAlertSyncTests.swift
+++ b/swift/Tests/ReminderCLITests/DueAlertSyncTests.swift
@@ -1,0 +1,100 @@
+import EventKit
+import XCTest
+@testable import ReminderCLI
+
+/// Reminders.app attaches an `EKAlarm(relativeOffset: 0)` to every TIMED reminder created in
+/// its UI and nothing to an all-day one. Measured across a live library: of 178 timed
+/// reminders 116 carry it, of 119 all-day reminders 115 carry nothing. `syncDueAlert` makes
+/// this CLI write the same shape, so a reminder created here is indistinguishable from one
+/// created in the app. These hold the edges of that rule.
+final class DueAlertSyncTests: XCTestCase {
+
+    private let store = EKEventStore()
+
+    private func makeReminder(year: Int? = 2026, month: Int? = 9, day: Int? = 2,
+                              hour: Int? = nil, minute: Int? = nil,
+                              offsets: [TimeInterval] = []) -> EKReminder {
+        let reminder = EKReminder(eventStore: store)
+        if let year, let month, let day {
+            var due = DateComponents()
+            due.year = year; due.month = month; due.day = day
+            due.hour = hour; due.minute = minute
+            reminder.dueDateComponents = due
+        }
+        for offset in offsets { reminder.addAlarm(EKAlarm(relativeOffset: offset)) }
+        return reminder
+    }
+
+    private func offsets(_ reminder: EKReminder) -> [TimeInterval] {
+        (reminder.alarms ?? []).map(\.relativeOffset)
+    }
+
+    func testATimedDueGetsTheAlertRemindersItselfWrites() {
+        let reminder = makeReminder(hour: 15, minute: 0)
+        syncDueAlert(reminder, enabled: true)
+        XCTAssertEqual(offsets(reminder), [0])
+    }
+
+    /// An alert on a date with no time of day resolves to midnight, which is not when anyone
+    /// wants to hear about it — and is why Reminders does not write one either.
+    func testAnAllDayDueGetsNothing() {
+        let reminder = makeReminder(hour: nil, minute: nil)
+        syncDueAlert(reminder, enabled: true)
+        XCTAssertTrue(offsets(reminder).isEmpty)
+    }
+
+    func testAReminderWithNoDueDateGetsNothing() {
+        let reminder = makeReminder(year: nil, month: nil, day: nil)
+        syncDueAlert(reminder, enabled: true)
+        XCTAssertTrue(offsets(reminder).isEmpty)
+    }
+
+    /// An explicit `--alarm` stays exactly what the caller asked for. Adding an offset-0
+    /// alarm beside an early one would not change what Reminders DISPLAYS — earliest wins,
+    /// see `earlyAlarmShift` — but it would add a second ping nobody requested.
+    func testAnExplicitAlarmIsLeftAlone() {
+        let reminder = makeReminder(hour: 15, minute: 0, offsets: [-900])
+        syncDueAlert(reminder, enabled: true)
+        XCTAssertEqual(offsets(reminder), [-900])
+    }
+
+    /// Specifically: the implicit alert must not resurrect the early-alarm warning by
+    /// stacking a second alarm, which would leave the reminder still displaying at 14:45
+    /// while now also pinging at 15:00.
+    func testAnExplicitAlarmKeepsTheDisplayedTimeSingleSourced() {
+        let reminder = makeReminder(hour: 15, minute: 0, offsets: [-900])
+        syncDueAlert(reminder, enabled: true)
+        XCTAssertEqual(reminder.alarms?.count, 1)
+        XCTAssertNotNil(earlyAlarmShift(for: reminder), "the early alarm still moves the label")
+    }
+
+    func testDisabledWritesNothing() {
+        let reminder = makeReminder(hour: 15, minute: 0)
+        syncDueAlert(reminder, enabled: false)
+        XCTAssertTrue(offsets(reminder).isEmpty)
+    }
+
+    /// Idempotent: re-running over a reminder that already carries the implicit alert must
+    /// not stack a duplicate. The update path can reach this on a second `--due` change.
+    func testRunningTwiceDoesNotStackDuplicates() {
+        let reminder = makeReminder(hour: 15, minute: 0)
+        syncDueAlert(reminder, enabled: true)
+        syncDueAlert(reminder, enabled: true)
+        XCTAssertEqual(offsets(reminder), [0])
+    }
+
+    /// A location alarm is still an alarm. The reminder already notifies on arrival, so
+    /// adding a time alert would be a second notification the caller never asked for.
+    func testALocationAlarmCountsAsAnAlarm() {
+        let reminder = makeReminder(hour: 15, minute: 0)
+        let alarm = EKAlarm()
+        let location = EKStructuredLocation(title: "Home")
+        location.radius = 100
+        alarm.structuredLocation = location
+        alarm.proximity = .enter
+        reminder.addAlarm(alarm)
+
+        syncDueAlert(reminder, enabled: true)
+        XCTAssertEqual(reminder.alarms?.count, 1)
+    }
+}

--- a/swift/Tests/ReminderCLITests/DueAlertSyncTests.swift
+++ b/swift/Tests/ReminderCLITests/DueAlertSyncTests.swift
@@ -83,6 +83,50 @@ final class DueAlertSyncTests: XCTestCase {
         XCTAssertEqual(offsets(reminder), [0])
     }
 
+    // MARK: - Retiming a timed reminder to all-day
+
+    /// Greptile P1 on #126: the implicit alert was added while the reminder was timed, then
+    /// the due date became all-day and the alarm stayed, resolving to a midnight ping.
+    func testRetimingToAllDayDropsTheImplicitAlert() {
+        let reminder = makeReminder(hour: 15, minute: 0)
+        syncDueAlert(reminder, enabled: true)
+        XCTAssertEqual(offsets(reminder), [0], "precondition: the implicit alert is there")
+
+        reminder.dueDateComponents = DateComponents(year: 2026, month: 9, day: 4)
+        syncDueAlert(reminder, enabled: true, dueDateChanged: true)
+        XCTAssertTrue(offsets(reminder).isEmpty)
+    }
+
+    /// The narrowing that keeps the strip from eating real data: an alarm carrying an
+    /// `absoluteDate` is the "all-day reminder, alert me at 9am" shape, which is what most
+    /// all-day alarms in a real library actually are.
+    func testRetimingToAllDayKeepsAnAbsoluteDateAlert() {
+        let reminder = makeReminder(hour: 15, minute: 0)
+        let alarm = EKAlarm(absoluteDate: Date(timeIntervalSince1970: 1_787_500_000))
+        reminder.addAlarm(alarm)
+
+        reminder.dueDateComponents = DateComponents(year: 2026, month: 9, day: 4)
+        syncDueAlert(reminder, enabled: true, dueDateChanged: true)
+        XCTAssertEqual(reminder.alarms?.count, 1)
+        XCTAssertNotNil(reminder.alarms?.first?.absoluteDate)
+    }
+
+    /// A genuine early offset is the caller's, not ours, and survives the transition.
+    func testRetimingToAllDayKeepsANonZeroOffset() {
+        let reminder = makeReminder(hour: 15, minute: 0, offsets: [-900])
+        reminder.dueDateComponents = DateComponents(year: 2026, month: 9, day: 4)
+        syncDueAlert(reminder, enabled: true, dueDateChanged: true)
+        XCTAssertEqual(offsets(reminder), [-900])
+    }
+
+    /// On create there is no previous state, so an explicit `--alarm 0` beside an all-day due
+    /// is a stated intent rather than a leftover. Nothing is stripped without the flag.
+    func testCreateLeavesAnExplicitZeroAlarmOnAnAllDayReminder() {
+        let reminder = makeReminder(hour: nil, minute: nil, offsets: [0])
+        syncDueAlert(reminder, enabled: true)
+        XCTAssertEqual(offsets(reminder), [0])
+    }
+
     /// A location alarm is still an alarm. The reminder already notifies on arrival, so
     /// adding a time alert would be a second notification the caller never asked for.
     func testALocationAlarmCountsAsAnAlarm() {


### PR DESCRIPTION
Closes the open question left by #117/#118: a timed reminder created through this CLI carried no `EKAlarm` at all, while one created in Reminders.app always carries `EKAlarm(relativeOffset: 0)` — an alert **at** the due moment.

## The answer is in the library, not in a spec

| Due kind | With alarm | Without |
| --- | --- | --- |
| **Timed** (`09:00`) | **116** | 62 |
| **All-day** (date only) | 4 | **115** |

Apple syncs a mandatory alert to the due time, but **only for timed reminders**. That inverted ratio is the design stated in data, and the 62 timed reminders missing an alarm were the ones this CLI wrote.

## What changed

`syncDueAlert` attaches `relativeOffset: 0` to a timed due date and nothing to an all-day one. An alert on a date with no time of day resolves to midnight, which is not when anyone wants to hear about it, and is why Reminders does not write one either.

| Case | Result |
| --- | --- |
| timed due, no `--alarm` | `[{relativeOffset: 0}]` |
| all-day due | none |
| timed due + `--alarm 15` | `[{relativeOffset: -900}]` — untouched |
| timed due + `--no-due-alert` | none |
| no due date | none |
| update: retitle only | **no alarm added** |
| update: set a timed `--due` | `[{relativeOffset: 0}]` |
| update: set an all-day `--due` | none |

All nine verified against live EventKit, not just unit tests.

An explicit `--alarm` is left exactly as passed. Stacking an offset-0 alarm beside an early one would not change what Reminders *displays* — earliest wins, see `earlyAlarmShift` from #118 — but it would add a second ping nobody asked for.

On update it is gated on `--due` being present, so an unrelated edit never grows an alarm. In batch-create it runs **before** `eventStore.save`; my first cut had it after, and mutating a staged object then relying on the later `commit` to notice is not a contract EventKit offers.

## What this deliberately does not claim

**That the alarm is what makes the notification fire.** I could not verify that:

- The first attempt (in #118) watched the `usernoted` database. That database holds 473 records across Teams, GitHub, Messages and others, and has **never** held a single `com.apple.reminders` row — so it could not have detected the event either way. That earlier "no notification arrived" observation was meaningless.
- The second attempt used screen capture with Focus confirmed off at 10:39 local, with an offset-0 control. **Neither** probe produced a visible banner, and `ncprefs` could not be parsed to confirm Reminders notifications are even enabled on this machine. So the test cannot distinguish "alarm-less is mute" from "notifications are off here".

The justification for this change is therefore the verified one — match the representation the owning app produces, so a reminder created here is indistinguishable from one created in Reminders — not the unverified one about firing. If the alarm *is* load-bearing for delivery, this fixes silent reminders as a side effect.

## Backfill

The 11 existing incomplete, future-dated, timed reminders that lacked an alarm were backfilled by re-setting their existing due date. Due dates unchanged; all-day reminders carrying alarms stayed at 4, so no collateral edits.

Deliberately skipped: 50 **completed** reminders (an alert on a finished task is pointless, and touching 50 records is risk without benefit). There were **zero** incomplete past-due ones, which is what made this safe — backfilling those could have fired a burst of overdue notifications.

## Testing

- `swift test`: **299 passed**, 0 failures (up from 291; 8 new in `DueAlertSyncTests`)
- `mcp-server`: **86 passed** (up from 83)
- `npm run eval`: 146/148. The 2 failures are in `tests/calendar-reasoning.test.js`, the model-in-the-loop suite CLAUDE.md documents as non-deterministic. They concern *calendar* reasoning, are unrelated to this change, and CI skips them via `SKIP_MODEL_EVALS=1`. All 4 deterministic eval files pass.
- Probe reminders created against live data were deleted; verified none remain.