### PR TITLE
fix(evals): correct two calendar rubrics that graded correct answers wrong

### DIFF
--- a/evals/scenarios/calendar-reasoning.yaml
+++ b/evals/scenarios/calendar-reasoning.yaml
@@ -75,9 +75,16 @@ scenarios:
     grading:
       must_identify_available:
         - "2026-04-01"                  # Wednesday - work events end by 1 PM
-        - "2026-04-08"                  # Wednesday - dentist+OPG end by 3 PM
         - "2026-04-10"                  # Friday - board meeting ends at 1 PM (Sarah leaves)
       must_identify_blocked:
+        # April 8 is a Wednesday whose only events (dentist, OPG) end by 3 PM, which is why
+        # it used to sit in must_identify_available. But it falls INSIDE "Sarah Easter
+        # Break" (all-day Apr 2 -> Apr 10; an all-day end is exclusive, so it covers Apr
+        # 2..Apr 9), and this prompt says to exclude dates when Sarah is visiting while
+        # system_context says visits block the whole stretch. Blocked is the only answer
+        # consistent with what the model was told; as an "available" it marked a correct
+        # response wrong. The neighbouring Apr 10 comment already knew Sarah leaves then.
+        - "2026-04-08"                  # Wednesday - inside Sarah's Easter Break
         - "2026-04-02"                  # Thursday - Sarah pickup + Easter break
         - "2026-04-03"                  # Friday - Canlis already booked
         - "2026-04-09"                  # Thursday - Joyce dinner already booked
@@ -89,7 +96,12 @@ scenarios:
   - id: dinner-already-booked
     description: "Must recognize existing dinner events and not suggest those evenings as 'open'"
     fixture: "calendar/multi-week-schedule"
-    user_message: "Which evenings this week (Mar 31 - Apr 6) already have dinner plans?"
+    # Asked as "dinner plans" this contradicted its own rubric: the Wildwood Budget
+    # Ratification Meeting is a 7:00-9:30 PM MEETING, not a dinner, so a model answering
+    # the question as written correctly omitted it and failed must_mention. The
+    # must_not_claim_open expectations show the intent was evening OCCUPANCY, so the
+    # question is what needed fixing rather than the expectations.
+    user_message: "Which evenings this week (Mar 31 - Apr 6) already have something booked in the dinner slot?"
     grading:
       must_mention:
         - "Wildwood Budget"             # Mar 31 evening


### PR DESCRIPTION
Two of the three eval failures were the **rubric** being wrong, not the model. One was not, and I left it failing on purpose.

## 1. `open-evening-identification` required a contradiction

It expected **April 8 to be AVAILABLE**. April 8 falls inside `Sarah Easter Break`, an all-day event running Apr 2 → Apr 10 (an all-day end is exclusive, so it covers Apr 2–9). Meanwhile:

- the scenario's own prompt says *"Exclude dates when Sarah is visiting"*
- `system_context` says *"multi-day events (trips, **visits**) block the whole stretch"*

So a model following both instructions correctly marks April 8 blocked — and was graded wrong for it. Observed verbatim earlier:

> `must_identify_available: 2026-04-08: Response explicitly marks April 8 as blocked (❌) due to 'Sarah visiting (Easter Break)'`

The give-away that this was an oversight rather than a judgement call is the neighbouring expectation's own comment:

```yaml
- "2026-04-10"   # Friday - board meeting ends at 1 PM (Sarah leaves)
```

The author already knew the visit ran through the 9th. Moved April 8 to `must_identify_blocked`.

This was masked by the scenario's `passThreshold: 0.8` — it scored 8/9 and "passed", so the contradiction sat there teaching the suite to tolerate a wrong answer.

## 2. `dinner-already-booked` asked a different question than it graded

It asked *"which evenings already have **dinner plans**?"* while requiring the answer to name the **Wildwood Budget Ratification Meeting** — a 7:00–9:30 PM meeting, not a dinner. A model answering the question as written correctly omits it and fails `must_mention`.

The rubric's own `must_not_claim_open: [2026-03-31, 2026-04-03]` shows the intent was evening **occupancy**, so the question was the broken half. It now asks which evenings *already have something booked in the dinner slot*, which the meeting genuinely does.

Both scenarios verified passing after the change.

## 3. NOT fixed — `blocking-range-sarah-visit` is a true positive

It expects April 1 to be available, and that is **correct**: April 1 holds only the Bessemer Summit, 8 AM–1 PM. The model marked it blocked, citing the Wildwood Budget meeting at 7:00–9:30 PM. That event is on **March 31 local**:

```
localStart = 2026-03-31 7:00 PM
startDate  = 2026-04-01T02:00:00Z     <-- the model read this
```

It read the UTC date instead of `localStart` — precisely the trap this suite exists to catch, and precisely what `system_context` warns about in its first two lines. Weakening the assertion or adding a `passThreshold` would delete the signal, so I left it.

Worth noting: the two **dedicated** UTC scenarios (`utc-cross-midnight`, `utc-cross-midnight-april3`) both pass. The mistake shows up when the UTC question is incidental to a larger task rather than being the whole task, which is the more interesting finding and the more realistic failure mode.

## Cost note

These are model-in-the-loop with an LLM judge, so verification was per-scenario rather than full-suite runs (~$0.30 and ~30–90s each, against ~$2.31 and ~8 min for all eight). CI skips them entirely via `SKIP_MODEL_EVALS=1`; all 4 deterministic eval files were unaffected throughout.