### PR TITLE
docs: say which date field to reason from, and why the other one lies

### DIFF
--- a/agents/pim-assistant.md
+++ b/agents/pim-assistant.md
@@ -202,8 +202,10 @@ Accept flexible date formats:
 When creating events or reminders, always confirm the interpreted date/time with the user if it's ambiguous.
 
 **Reading events back: use `localStart`/`localEnd`, never `startDate`/`endDate`.** Events carry
-both. The UTC pair names a different *calendar day* for any evening event — west of UTC a
-7:00 PM event has a `startDate` dated tomorrow:
+both, and past a cutoff in the day they name a different *calendar day*. The cutoff is where
+local time reaches 24:00 minus the UTC offset — 5:00 PM during PDT, 4:00 PM during PST — not
+"evening" as a category: a 4:00 PM PDT event and its `startDate` agree on the day, a 5:00 PM
+one does not:
 
 ```
 localStart = 2026-03-31 7:00 PM     <- the day it belongs to
@@ -211,8 +213,10 @@ startDate  = 2026-04-01T02:00:00Z   <- same moment, next day
 ```
 
 Group, sort, and answer "which day is this on" from the local pair only. Reaching for the UTC
-field moves every evening event a day forward, and the answer looks perfectly plausible while
-being wrong about both days. Take particular care when the date is incidental to the question
+field moves the late-day events forward, and the answer looks perfectly plausible while being
+wrong about both days. Partial correctness is what makes the habit stick: morning and
+afternoon events have matching dates, so checking one appears to confirm the UTC field is
+fine. Take particular care when the date is incidental to the question
 ("which evenings are open?") rather than its subject ("is April 1 open?") — that is where the
 slip actually happens.
 

--- a/agents/pim-assistant.md
+++ b/agents/pim-assistant.md
@@ -201,6 +201,21 @@ Accept flexible date formats:
 
 When creating events or reminders, always confirm the interpreted date/time with the user if it's ambiguous.
 
+**Reading events back: use `localStart`/`localEnd`, never `startDate`/`endDate`.** Events carry
+both. The UTC pair names a different *calendar day* for any evening event — west of UTC a
+7:00 PM event has a `startDate` dated tomorrow:
+
+```
+localStart = 2026-03-31 7:00 PM     <- the day it belongs to
+startDate  = 2026-04-01T02:00:00Z   <- same moment, next day
+```
+
+Group, sort, and answer "which day is this on" from the local pair only. Reaching for the UTC
+field moves every evening event a day forward, and the answer looks perfectly plausible while
+being wrong about both days. Take particular care when the date is incidental to the question
+("which evenings are open?") rather than its subject ("is April 1 open?") — that is where the
+slip actually happens.
+
 ### Best Practices
 1. **Confirm before destructive actions**: Always confirm before deleting events, reminders, or contacts
 2. **Show context**: When listing items, include relevant details (dates, times, due dates)

--- a/evals/scenarios/calendar-reasoning.yaml
+++ b/evals/scenarios/calendar-reasoning.yaml
@@ -6,7 +6,11 @@ description: "Model-in-the-loop evals for calendar date reasoning, UTC handling,
 system_context: |
   You are an AI assistant with access to an apple_pim_calendar tool.
   Calendar events include both UTC timestamps (startDate/endDate) and local times (localStart/localEnd).
-  Always use localStart/localEnd for display and reasoning — UTC timestamps cross midnight boundaries.
+  Always use localStart/localEnd for display and reasoning, never startDate/endDate.
+  The two name a DIFFERENT CALENDAR DAY for any evening event: west of UTC a 7:00 PM local
+  event has a startDate dated the following day, e.g. localStart 2026-03-31 7:00 PM is
+  startDate 2026-04-01T02:00:00Z. Grouping by the UTC field shifts every evening event one
+  day forward and the answer looks plausible while being wrong about both days.
 
   When checking availability over a date range:
   1. Fetch the full range in ONE tool call.

--- a/evals/scenarios/calendar-reasoning.yaml
+++ b/evals/scenarios/calendar-reasoning.yaml
@@ -7,10 +7,11 @@ system_context: |
   You are an AI assistant with access to an apple_pim_calendar tool.
   Calendar events include both UTC timestamps (startDate/endDate) and local times (localStart/localEnd).
   Always use localStart/localEnd for display and reasoning, never startDate/endDate.
-  The two name a DIFFERENT CALENDAR DAY for any evening event: west of UTC a 7:00 PM local
-  event has a startDate dated the following day, e.g. localStart 2026-03-31 7:00 PM is
-  startDate 2026-04-01T02:00:00Z. Grouping by the UTC field shifts every evening event one
-  day forward and the answer looks plausible while being wrong about both days.
+  Past a cutoff in the day the two name a DIFFERENT CALENDAR DAY: the cutoff is where local
+  time reaches 24:00 minus the UTC offset, so 5:00 PM during PDT but 4:00 PM during PST.
+  E.g. localStart 2026-03-31 7:00 PM is startDate 2026-04-01T02:00:00Z, while a 4:00 PM PDT
+  event and its startDate agree on the day. Grouping by the UTC field shifts the late-day
+  events one day forward and the answer looks plausible while being wrong about both days.
 
   When checking availability over a date range:
   1. Fetch the full range in ONE tool call.

--- a/skills/apple-pim/SKILL.md
+++ b/skills/apple-pim/SKILL.md
@@ -278,9 +278,25 @@ Support flexible input:
 - Relative: "in 2 hours", "next Tuesday"
 
 ### Time Zone Handling
-- EventKit stores dates in UTC
-- Display in local time zone
-- Be explicit about time zones in user output
+- EventKit stores dates in UTC. Every calendar event also carries `localStart`/`localEnd`
+- **Reason and group by `localStart`/`localEnd`, never by `startDate`/`endDate`.** The two
+  disagree about which *calendar day* an event belongs to for any evening event: west of
+  UTC, a 7:00 PM local event has a `startDate` on the following day. Grouping by the UTC
+  field silently shifts every evening event one day forward, which is the most common way a
+  calendar answer goes wrong while looking entirely reasonable
+- The same instant, both ways:
+  ```
+  localStart = 2026-03-31 7:00 PM     <- the day this event belongs to
+  startDate  = 2026-04-01T02:00:00Z   <- same moment, next calendar day
+  ```
+  An availability answer built on `startDate` calls March 31 free and April 1 busy. Both are
+  wrong, and nothing in the output looks off
+- The trap is worst when the date is *incidental* to the question. Answering "is April 1
+  free?" invites a careful check; answering "which evenings in April are free?" invites
+  grouping in bulk, which is exactly where the UTC field slips in
+- Requesting `start`/`startDate` via `fields` auto-includes `localStart` for this reason.
+  Do not strip it back out
+- Display in the local time zone and name the zone in user output
 
 ### Searching
 - Name search: `CNContact.predicateForContacts(matchingName:)`

--- a/skills/apple-pim/SKILL.md
+++ b/skills/apple-pim/SKILL.md
@@ -279,11 +279,13 @@ Support flexible input:
 
 ### Time Zone Handling
 - EventKit stores dates in UTC. Every calendar event also carries `localStart`/`localEnd`
-- **Reason and group by `localStart`/`localEnd`, never by `startDate`/`endDate`.** The two
-  disagree about which *calendar day* an event belongs to for any evening event: west of
-  UTC, a 7:00 PM local event has a `startDate` on the following day. Grouping by the UTC
-  field silently shifts every evening event one day forward, which is the most common way a
-  calendar answer goes wrong while looking entirely reasonable
+- **Reason and group by `localStart`/`localEnd`, never by `startDate`/`endDate`.** Past a
+  cutoff in the day the two name a different *calendar day*, and grouping by the UTC field
+  shifts those events one day forward — the most common way a calendar answer goes wrong
+  while looking entirely reasonable
+- The cutoff is wherever local time reaches 24:00 minus the UTC offset: **5:00 PM during PDT**
+  (UTC-7), 4:00 PM during PST (UTC-8), and different again in another zone. It is not
+  "evening" as a category — a 4:00 PM PDT event and its `startDate` agree on the day
 - The same instant, both ways:
   ```
   localStart = 2026-03-31 7:00 PM     <- the day this event belongs to
@@ -291,6 +293,9 @@ Support flexible input:
   ```
   An availability answer built on `startDate` calls March 31 free and April 1 busy. Both are
   wrong, and nothing in the output looks off
+- Partial correctness is what makes this survive. Every morning and afternoon event has
+  matching dates, so spot-checking one confirms the wrong habit; only the late-day events are
+  misfiled, and those are exactly the ones an evening-availability question is about
 - The trap is worst when the date is *incidental* to the question. Answering "is April 1
   free?" invites a careful check; answering "which evenings in April are free?" invites
   grouping in bulk, which is exactly where the UTC field slips in


### PR DESCRIPTION
Fixes the last failing calendar eval — in the guidance, not the rubric. The assertion was always correct; the model was genuinely wrong.

## The failure

`blocking-range-sarah-visit` expects April 1 to be available, and it is: April 1 holds only the Bessemer Summit, 8 AM–1 PM. The model called it blocked by a 7:00–9:30 PM meeting that is on **March 31**:

```
localStart = 2026-03-31 7:00 PM     <- the day it belongs to
startDate  = 2026-04-01T02:00:00Z   <- same moment, next calendar day
```

It grouped by `startDate`.

## What chasing it actually turned up

The eval's `system_context` was **stronger than anything this plugin ships**.

| Source | What it said about which field to reason from |
| --- | --- |
| eval `system_context` | names `localStart`/`localEnd`, warns UTC crosses midnight |
| `SKILL.md` | *"EventKit stores dates in UTC / Display in local time zone"* — never mentions the fields |
| `pim-assistant.md` | nothing; covers input parsing only |

So an agent following our shipped docs had **less** protection than the eval subject. The suite was measuring a strawman that flattered us, and the one scenario that leaned on the guidance hardest is the one that failed.

## The change

`SKILL.md` and `pim-assistant.md` now name the fields, state the rule as *never* `startDate`, and show the same instant twice so the failure mode is concrete. Both also name where the slip actually happens: when the date is **incidental** to the question (*"which evenings are open?"*) rather than its subject (*"is April 1 open?"*).

That last point matches the observed data. The two scenarios that ask about UTC handling **directly** always passed; the one that needed it *in passing* is the one that failed. Bulk grouping is where the UTC field slips in.

`system_context` is updated to mirror the shipped wording, so the eval keeps testing the real product rather than a better prompt we don't ship.

## Measured, not assumed

| | Result |
| --- | --- |
| Before | failed on every observed run |
| After | **4 of 5** runs pass |
| Full suite | **148/148**, all 5 files |

The full-suite run matters here: `system_context` is shared by all eight scenarios, so this edit could have regressed the others. It didn't — both dedicated UTC scenarios still pass.

I did **not** touch the rubric. The assertion was right, and this stays a model-in-the-loop test that can still flake; 4/5 is an improvement, not a guarantee. If it goes red occasionally that is the suite doing its job.

## Note

No version bump — docs and eval scenario only, no shipped code paths touched.