### PR TITLE
docs: settle whether an alarm-less reminder fires — it does

### DIFF
--- a/skills/apple-pim/SKILL.md
+++ b/skills/apple-pim/SKILL.md
@@ -215,7 +215,10 @@ When reading events/reminders, the `recurrence` array includes:
    indistinguishable from one created in the app. All-day dues get nothing — an alert on a
    date with no time resolves to midnight. An explicit `alarm` is left exactly as passed.
    Opt out with `dueAlert: false` (`--no-due-alert`). On update this applies only when `due`
-   is also being set, so an unrelated edit never grows an alarm
+   is also being set, so an unrelated edit never grows an alarm.
+   This is about matching Apple's representation, **not** about whether the reminder fires:
+   dated reminders written with no alarm at all do still notify. Do not re-investigate that;
+   it is settled
 10. **`startDate` mirrors the due date and is returned on reads** — Reminders offers no separate
    start-date control, so the CLI keeps the two in sync on every write. A reminder that ends up
    with a start date but no due date renders as *dateless* in Reminders while still occupying a

--- a/swift/Sources/ReminderCLI/ReminderCLI.swift
+++ b/swift/Sources/ReminderCLI/ReminderCLI.swift
@@ -225,11 +225,15 @@ func reminderToDict(_ reminder: EKReminder) -> [String: Any] {
 /// missing it are the ones this CLI wrote.
 ///
 /// Writing it makes a reminder created here indistinguishable from one created in the app.
-/// Whether the alarm is ALSO what makes the notification fire is deliberately not claimed:
-/// an attempt to observe delivery was inconclusive (no banner for either an alarm-less
-/// reminder or an offset-0 control, and Reminders' own notification settings could not be
-/// read), so this is justified by matching Apple's representation, which is verified, rather
-/// than by a claim about firing, which is not.
+///
+/// It does NOT control whether the reminder fires. Dated reminders written by this CLI with
+/// no alarm at all did notify, confirmed by the person who had been receiving them for
+/// months; two attempts to observe delivery programmatically were both inconclusive and are
+/// not worth repeating (the usernoted database has never held a `com.apple.reminders` row,
+/// and a screen-capture probe could not rule out Reminders' notification settings). So this
+/// is a REPRESENTATION fix, not a delivery fix: the value is that a reminder created here
+/// matches one created in the app, which matters for round-tripping and for anything reading
+/// the store. Nothing was silently mute before it.
 ///
 /// All-day reminders get nothing, exactly as Reminders does it. An alert on a date with no
 /// time of day resolves to midnight, which is not when anyone wants to hear about it.


### PR DESCRIPTION
Closes the one thread left open by #126.

#126 shipped with a deliberate hedge: it matched Apple's representation but declined to claim the alarm had anything to do with **delivery**, because two attempts to observe a notification were inconclusive.

That question is now answered, by the only detector that actually worked — the person who had been receiving these reminders for months. **Dated reminders written by this CLI with no alarm at all did notify.**

## What that changes

`syncDueAlert` is a **representation** fix, not a delivery fix. Its value is that a reminder created here matches one created in Reminders, which matters for round-tripping and for anything reading the store. Nothing was silently mute before it, and #126's backfill of 11 reminders corrected consistency rather than rescuing lost alerts.

Worth being explicit since I raised the alarm on this: the worry that "every dated reminder this plugin ever created never fired" was **unfounded**.

## Why write it down

The hedge in the code comment invited someone to go re-investigate. Both dead ends are now recorded in agent memory so they are not walked again:

- the `usernoted` database has never held a single `com.apple.reminders` row across 473 records, so its silence was never evidence
- the screen-capture probe could not rule out Reminders' own notification settings, because `com.apple.ncprefs.plist` would not parse

The code comment and `SKILL.md` now state the answer with an explicit "do not re-investigate".

No behaviour change, no version bump — comment and doc only.