### PR TITLE
fix(deps): group Dependabot security updates per directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,15 @@ updates:
     schedule:
       interval: monthly
     groups:
+      # ⚠️ Security updates are NOT grouped by default, so a repo with three
+      # advisories in one lockfile gets three PRs that all edit it. Merging any
+      # one invalidates the other two, `@dependabot recreate` rebuilds them,
+      # and the next merge breaks them again -- a loop this fleet actually hit
+      # on Lobster, findmy-cli and openclaw-parcel. One PR per directory ends it.
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
       production:
         dependency-type: production
       development:
@@ -30,6 +39,15 @@ updates:
     schedule:
       interval: monthly
     groups:
+      # ⚠️ Security updates are NOT grouped by default, so a repo with three
+      # advisories in one lockfile gets three PRs that all edit it. Merging any
+      # one invalidates the other two, `@dependabot recreate` rebuilds them,
+      # and the next merge breaks them again -- a loop this fleet actually hit
+      # on Lobster, findmy-cli and openclaw-parcel. One PR per directory ends it.
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
       production:
         dependency-type: production
       development:


### PR DESCRIPTION
Security updates are **not grouped by default**, so a repo with several advisories in one lockfile gets several PRs that all edit that lockfile. Merging any one invalidates the rest, `@dependabot recreate` rebuilds them, and the next merge breaks them again.

Lobster, findmy-cli and openclaw-parcel were stuck in exactly that loop tonight — recreated, went green, conflicted again on the next merge. Twice.

`applies-to: security-updates` collapses them into **one PR per directory**, which ends the thrash.