### PR TITLE
fix(ci): deploy-site needs node 24 for astro 7

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
#138 (astro 5 → 7) merged green and then failed at deploy: `deploy-site.yml` pins `node-version: 20`, and astro 7 requires `>=22.12.0`.

```
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```

Nothing was published — the build failed before the wrangler step — so the live site is still serving the previous build rather than a broken one. 24 matches every other workflow in this repo.

This is precisely the failure mode of `deploy-site.yml` only triggering on push to `main`: no pull request ever runs the site build, so the first time the new stack met this runner was after merge. Worth considering a build-only job on `pull_request` with a `site/**` path filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDD6P9ft7DNNbrXpNWvCsk