### PR TITLE
fix(mail): enforce the ingress strength gate without trusting the kernel

### DIFF
--- a/docs/mail-channel-scenarios.md
+++ b/docs/mail-channel-scenarios.md
@@ -498,6 +498,19 @@ If it scored `asserted`, this row would be decorative and I2, I7, and I8 would a
 The channel reports any `allowFrom` entry with no enrollment behind it at startup, so the
 gap between the two files is visible rather than inferred.
 
+The bar is enforced twice, on purpose. The ingress kernel resolves it as `min(entry,
+subject)`, and `resolveMailIngress` re-reads the subject strength itself before treating a
+kernel admit as an admit. That is one term checked twice rather than two policies that can
+disagree: this channel pins entry-side authentication to `verified`, so the kernel's minimum
+reduces to exactly the strength the local check reads.
+
+The second check exists because the first was silently absent once. `minIdentifierAuthentication`
+is an ordinary property and `IdentifierAuthentication` a type-only import, so both erase at
+runtime: a build against an SDK that ships the kernel, running against openclaw < 2026.8.1,
+resolved every import, dropped the gate, and dispatched I2, I7, and I8. Nothing raised. The
+plugin now imports `meetsIdentifierAuthentication` as a value, so an SDK without the kernel
+fails to link the module instead — the channel does not start, rather than starting open.
+
 Every default is closed. An install that configures nothing reads nothing and sends nothing,
 which is the correct resting state for a system whose failure mode is an agent acting on a
 stranger's instructions.

--- a/openclaw/src/mail-channel/inbound.ts
+++ b/openclaw/src/mail-channel/inbound.ts
@@ -11,6 +11,7 @@
 
 import {
   defineStableChannelIngressIdentity,
+  meetsIdentifierAuthentication,
   resolveChannelMessageIngress,
 } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import {
@@ -270,6 +271,11 @@ export type MailIngressParams = {
   minIdentifierAuthentication: IdentifierAuthentication;
   /** Conversation the kernel scopes this resolution to; the thread key in practice. */
   conversationId: string;
+  /**
+   * The ingress kernel, injectable so the strength gate below can be tested against a
+   * kernel that admits everything. Defaults to the SDK's. Nothing in production passes it.
+   */
+  resolveIngress?: typeof resolveChannelMessageIngress;
 };
 
 /**
@@ -291,7 +297,7 @@ export async function resolveMailIngress(
       ? [...params.allowFrom, params.address]
       : [...params.allowFrom];
 
-  const kernel = await resolveChannelMessageIngress({
+  const kernel = await (params.resolveIngress ?? resolveChannelMessageIngress)({
     channelId: "apple-mail",
     accountId: "default",
     identity: MAIL_INGRESS_IDENTITY,
@@ -306,10 +312,37 @@ export async function resolveMailIngress(
     allowFrom: effectiveAllowFrom,
   });
 
+  // Re-check the authentication half of the kernel's admit locally, and refuse to treat an
+  // admit that fails it as an admit.
+  //
+  // This is not a second policy. The channel pins entry-side authentication to `verified`
+  // (MAIL_INGRESS_IDENTITY), so the kernel's min(entry, subject) reduces to exactly the
+  // subject strength this line reads: one term, asserted twice, not two policies that can
+  // disagree.
+  //
+  // It is here because the gate was silently absent once and nothing raised. Every binding
+  // this module had to the identifier-authentication kernel was erasable: `IdentifierAuthentication`
+  // is a type-only import, and `minIdentifierAuthentication` is an ordinary property that an
+  // SDK predating the kernel drops on the floor. Built against a kernel-bearing SDK and run
+  // against openclaw < 2026.8.1, the module loaded, every import resolved, the gate stopped
+  // running, and I2/I7/I8 -- an allowlisted address with nothing behind it, a forged
+  // Authentication-Results, an attacker's own valid SPF -- were dispatched. Measured, not
+  // theorized: pinning openclaw@2026.7.1-2 turns 8 tests in this repo red on exactly those
+  // rows.
+  //
+  // `meetsIdentifierAuthentication` is imported as a VALUE for the same reason. An SDK
+  // without the kernel cannot satisfy that named import, so the module fails to link and the
+  // channel does not start -- loud and closed, rather than quiet and open. `compat.pluginApi`
+  // states the same floor, but it is enforced by the host; this holds when the host does not.
+  const strengthSufficient = meetsIdentifierAuthentication(
+    params.strengths.address,
+    params.minIdentifierAuthentication,
+  );
+
   return {
     kernelReasonCode: kernel.ingress.reasonCode,
     decision: decideIngress({
-      kernelAdmitted: kernel.ingress.admission === "dispatch",
+      kernelAdmitted: kernel.ingress.admission === "dispatch" && strengthSufficient,
       domainVerified: params.strengths.domain === "verified",
       allowlisted: params.allowlisted,
       selfAddressed: params.selfAddressed,

--- a/openclaw/src/mail-channel/scenarios.test.ts
+++ b/openclaw/src/mail-channel/scenarios.test.ts
@@ -21,6 +21,7 @@ import {
   type MailAuthCheckResult,
   type MailIdentifierStrengths,
 } from "../mail-auth/strength.ts";
+import { meetsIdentifierAuthentication } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import { resolveMailIngress } from "./inbound.ts";
 import type { Admission } from "./policy.ts";
 
@@ -375,5 +376,94 @@ describe("scenario doc: invariants across the table", () => {
     assert.ok(spoofed, "I7 is the spoofed-operator row");
     const admission = await admissionFor({ auth: spoofed.auth, allowlisted: true }, "mutable");
     assert.equal(admission, "dispatch", "break-glass means exactly that");
+  });
+});
+
+/**
+ * The same table, run against a kernel with no authentication gate at all.
+ *
+ * This is the regression that shipped and was invisible. `minIdentifierAuthentication` is an
+ * ordinary property and `IdentifierAuthentication` a type-only import, so both erase at
+ * runtime: a build against a kernel-bearing SDK, running on openclaw < 2026.8.1, resolved
+ * every import, dropped the gate, and dispatched I2, I7 and I8. Pinning openclaw@2026.7.1-2
+ * reproduces it exactly -- 8 tests in this file and its neighbours go red on those rows.
+ *
+ * `failOpenKernel` is that SDK's behaviour distilled: admit everything the allowlist lets
+ * through, gate nothing. What these tests pin is that the channel refuses the spoofs anyway,
+ * so the admission no longer depends on the kernel choosing to enforce it.
+ *
+ * Scope is deliberately the authentication half only. The kernel still owns the allowlist,
+ * and a fail-open kernel does admit strangers (I5, I6) -- those rows are the kernel's job and
+ * are covered by the real-kernel table above.
+ */
+describe("the strength gate holds without the kernel", () => {
+  /** A kernel that admits every message it is handed. */
+  const failOpenKernel = (async () => ({
+    ingress: { admission: "dispatch", reasonCode: "fail_open_stub" },
+  })) as unknown as NonNullable<Parameters<typeof resolveMailIngress>[0]["resolveIngress"]>;
+
+  async function admissionWithoutKernelGate(
+    row: Pick<Row, "auth" | "allowlisted" | "selfAddressed" | "threadPermitted">,
+    minimum: IdentifierAuthentication,
+  ): Promise<Admission> {
+    const strengths = mailAuthToIdentifierStrengths(row.auth);
+    const address = row.auth.sender ?? "sender@example.test";
+    const resolved = await resolveMailIngress({
+      address,
+      strengths,
+      allowFrom: row.allowlisted ? [address] : [],
+      allowlisted: row.allowlisted ?? false,
+      selfAddressed: row.selfAddressed ?? false,
+      threadPermitted: row.threadPermitted ?? false,
+      minIdentifierAuthentication: minimum,
+      conversationId: "scenario-thread",
+      resolveIngress: failOpenKernel,
+    });
+    return resolved.decision.admission;
+  }
+
+  // The three rows the regression actually dispatched, named individually so a failure here
+  // reads as the security finding it is rather than as a table mismatch.
+  for (const id of ["I2", "I7", "I8"] as const) {
+    it(`${id} is still refused when the kernel gates nothing`, async () => {
+      const row = ROWS.find((r) => r.id === id);
+      assert.ok(row, `${id} is in the table`);
+      assert.notEqual(
+        await admissionWithoutKernelGate(row, "asserted"),
+        "dispatch",
+        `${id} at the default \`asserted\` minimum`,
+      );
+      assert.notEqual(
+        await admissionWithoutKernelGate(row, "verified"),
+        "dispatch",
+        `${id} at the strict \`verified\` minimum`,
+      );
+    });
+  }
+
+  // The general form: no row whose address is too weak for the configured minimum reaches an
+  // agent, whatever the kernel says. Stated over the whole table so a row added later is
+  // covered without anyone remembering to extend the list above.
+  it("dispatches nothing below the configured minimum, whatever the kernel returns", async () => {
+    for (const minimum of ["asserted", "verified"] as const) {
+      for (const row of ROWS) {
+        const strengths = mailAuthToIdentifierStrengths(row.auth);
+        if (meetsIdentifierAuthentication(strengths.address, minimum)) {
+          continue;
+        }
+        assert.notEqual(
+          await admissionWithoutKernelGate(row, minimum),
+          "dispatch",
+          `${row.id} (address ${strengths.address}) at minimum ${minimum}`,
+        );
+      }
+    }
+  });
+
+  // Guards the claim the production comment makes: the value import is what turns a
+  // kernel-less SDK into a link error instead of a silent fail-open. A type-only import
+  // would satisfy the compiler and vanish here.
+  it("binds the kernel primitive as a runtime value, not an erasable type", () => {
+    assert.equal(typeof meetsIdentifierAuthentication, "function");
   });
 });


### PR DESCRIPTION
Closes #130.

## Which side was wrong: neither

#130 reports 16 assertion failures in the mail ingress admission suite on `main`, with I2, I7 and I8 returning `dispatch` where the scenario table says `drop`. The suite was right and the code was right. It was being run against an SDK that predates the kernel it calls.

Established by measurement, not inspection:

| Check | Result |
|---|---|
| `npm test` in `openclaw/` on `main`, `openclaw@2026.8.1` | 251/251, exit 0 |
| Same tree, `npm i --no-save openclaw@2026.7.1-2` | 8 tests fail, on I2/I3/I4a/I7/I8/I9 and their three neighbours |
| `2026.7.1-2` `dist/plugin-sdk/channel-ingress-runtime.d.ts` | exports neither `IdentifierAuthentication` nor `meetsIdentifierAuthentication` |
| `2026.8.1` same file | exports both |
| CI run [33466124237](https://github.com/omarshahine/apple-pim/actions/runs/33466124237) on `main` | `OpenClaw Plugin` job: **RAN**, 251 pass / 0 fail against `openclaw@2026.8.1` |

`openclaw@2026.8.1` published as `latest` and the `OpenClaw Plugin` job's capability probe self-enabled, exactly as #124 designed it to. So the reported failure is already gone on `main`.

## What is not gone, and is fixed here

The failure mode itself is still reachable at runtime, and that is the part worth not papering over.

Every binding this module had to the identifier-authentication kernel was erasable at runtime:

- `IdentifierAuthentication` was a **type-only** import.
- `minIdentifierAuthentication` is an **ordinary property** on the params object. An SDK whose `ChannelIngressPolicyInput` has no such field drops it silently.

So a build against a kernel-bearing SDK, installed alongside `openclaw < 2026.8.1`, loads cleanly, resolves every import, stops gating authentication, and dispatches spoofed senders. Nothing raises. `compat.pluginApi: ">=2026.8.1"` states the floor, but the host enforces it and the plugin did not.

Three changes:

1. **`resolveMailIngress` re-reads the subject strength** and refuses to treat a kernel admit that fails it as an admit. This is one term asserted twice, not two policies that can disagree: the channel pins entry-side authentication to `verified` via `MAIL_INGRESS_IDENTITY`, so the kernel's `min(entry, subject)` reduces to exactly the strength the local check reads. Scope is the authentication half only; the kernel still owns the allowlist.
2. **`meetsIdentifierAuthentication` is imported as a value.** An SDK without the kernel cannot satisfy that named import, so the module fails to link and the channel does not start. Loud and closed, instead of quiet and open. Verified against the real old SDK rather than assumed:

   ```
   $ node -e "..." # openclaw@2026.7.1-2 installed
   SyntaxError: The requested module 'openclaw/plugin-sdk/channel-ingress-runtime'
   does not provide an export named 'meetsIdentifierAuthentication'
   exit=1
   ```
3. **The kernel is injectable** (`resolveIngress`, defaulted, unused in production) so the scenario table can be run against a kernel that gates nothing.

## A published SDK triggers this today

Not hypothetical. `openclaw@2026.9.1-beta.1` — published 2026-08-28, on the `beta` dist-tag, and **newer than 2026.8.1 by every version ordering** — ships `resolveChannelMessageIngress` and neither half of the authentication contract:

| Symbol in `2026.9.1-beta.1` `dist/` | |
|---|---|
| `resolveChannelMessageIngress` | PRESENT |
| `meetsIdentifierAuthentication` | **MISSING** |
| `minIdentifierAuthentication` | **MISSING** |

So on that SDK the released plugin resolves its imports, silently drops the gate, and dispatches I2/I7/I8 — the precise failure mode, on a currently published release. `>=2026.8.1` does not match prereleases, so a default `npm install` will not land there; someone tracking `openclaw@beta` will. With this PR that host gets a link failure and a channel that refuses to start instead.

It is also the concrete case that justifies the probe in `.github/actions/openclaw-sdk-contract` asserting the capability rather than comparing versions: here, version order and capability point in opposite directions.

## Tests

`openclaw/src/mail-channel/scenarios.test.ts` gains a `the strength gate holds without the kernel` suite: a `failOpenKernel` stub that admits everything, then I2/I7/I8 named individually, plus the general invariant over the whole table (nothing below the configured minimum dispatches, whatever the kernel returns), plus an assertion that the kernel primitive is bound as a runtime value rather than an erasable type.

Negative control run, so the tests are known to bite:

```
# with `&& strengthSufficient` neutered
ℹ tests 256   ℹ pass 252   ℹ fail 4
  ✖ I2 is still refused when the kernel gates nothing
  ✖ I7 is still refused when the kernel gates nothing
  ✖ I8 is still refused when the kernel gates nothing
  ✖ dispatches nothing below the configured minimum, whatever the kernel returns

# as committed
ℹ tests 256   ℹ pass 256   ℹ fail 0
```

`npx tsc --noEmit` clean, `npm run build` clean.

## Version

Left at 3.16.0 in this PR; a single bump to 3.16.1 follows once the four issue PRs land, so they do not all conflict on the same five manifests.

**Correcting #130 on one point:** it says 3.16.0 "is not tagged or published anywhere ... npm and ClawHub both still serve 3.15.0". That was true when it was filed and stale within hours — `v3.16.0` was tagged, released, and published to npm (`latest` = 3.16.0) at 2026-08-31T23:11Z.

That makes this PR a fix to a shipped release rather than pre-release hardening. It is not a live exploit for a fresh install: 3.16.0 declares `openclaw >=2026.8.1` in `peerDependencies` and `compat.pluginApi`, and 2026.8.1 is published, so a clean resolve gets a kernel-bearing SDK. The exposure is a host that already sits below that floor, where the declaration is the only thing standing between a spoofed sender and a dispatch — and the declaration is enforced by the host, not the plugin. This PR makes the plugin hold it too.

Nothing here releases, tags, or publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDD6P9ft7DNNbrXpNWvCsk


