### PR TITLE
fix(helper): reap stale helpers again by matching the launcher layout

### DIFF
--- a/lib/cli-runner.js
+++ b/lib/cli-runner.js
@@ -182,14 +182,37 @@ function parseEtimeSeconds(etime) {
 }
 
 /**
+ * `pgrep -f` pattern matching the resident dispatcher process, as an extended regex.
+ *
+ * The literal it replaces, "PIMHelper.app/Contents/MacOS/pim-helper", stopped matching
+ * anything when the bundle gained a Mach-O launcher. CFBundleExecutable is now a compiled
+ * stub that execv()s /bin/zsh on a path it builds by appending "/../Resources/pim-helper.sh"
+ * to its own directory WITHOUT normalizing it (helper/launcher.c), so the resident process
+ * command line reads:
+ *
+ *     /bin/zsh ~/Applications/PIMHelper.app/Contents/MacOS/../Resources/pim-helper.sh ...
+ *
+ * "Contents/MacOS/" is present and "Contents/MacOS/pim-helper" is not, so the old literal
+ * matched nothing, findHelperProcesses() always returned empty, and reapStaleHelpers() was
+ * silently a no-op against exactly the -1712 wedge it exists to clear.
+ *
+ * This is the pattern scripts/doctor.sh already uses. It matches both layouts -- the
+ * launcher's ".../Contents/MacOS/../Resources/pim-helper.sh" and the pre-launcher bundles
+ * still installed in the wild, whose script sat at "Contents/MacOS/pim-helper".
+ *
+ * It must NOT match the `open -W -a ~/Applications/PIMHelper.app --args ...` parent this
+ * runner spawns. It doesn't: that argv names the bundle but never descends into it, so it
+ * carries no "Contents/". This matters more than the widening does -- killing the parent
+ * would abort a live call rather than clear a wedged one.
+ */
+export const HELPER_PROC_MARKER = "PIMHelper\\.app/Contents/.*pim-helper";
+
+/**
  * Find resident pim-helper dispatcher processes for the installed helper.
  * @returns {Promise<Array<{pid: number, ageSeconds: number|null}>>}
  */
-async function findHelperProcesses() {
-  // Match on the dispatcher script path inside the helper bundle so we
-  // never touch unrelated processes.
-  const marker = "PIMHelper.app/Contents/MacOS/pim-helper";
-  const { out } = await runQuick("/usr/bin/pgrep", ["-f", marker]);
+export async function findHelperProcesses() {
+  const { out } = await runQuick("/usr/bin/pgrep", ["-f", HELPER_PROC_MARKER]);
   const pids = out
     .split("\n")
     .map((l) => parseInt(l.trim(), 10))

--- a/mcp-server/test/cli-runner-helper-proc.test.js
+++ b/mcp-server/test/cli-runner-helper-proc.test.js
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HELPER_PROC_MARKER, findHelperProcesses } from "../../lib/cli-runner.js";
+
+// reapStaleHelpers() SIGKILLs whatever this pattern matches, so the pattern is the whole
+// safety boundary and a JS regex mirroring it would not test it. BSD pgrep -f applies its
+// own extended-regex engine to the joined argv, so these tests spawn processes with the real
+// argv shapes and run the real /usr/bin/pgrep.
+//
+// Membership, never set equality: a developer machine may well have a genuine PIMHelper
+// resident, and the test must not care.
+
+const isMacOS = process.platform === "darwin";
+const onMac = isMacOS ? describe : describe.skip;
+
+/** Sleeper whose argv[1] is `scriptPath` and whose remaining argv is `args`. */
+function spawnWithArgv(scriptPath, args = []) {
+  writeFileSync(scriptPath, "sleep 120\n");
+  const child = spawn("/bin/zsh", [scriptPath, ...args], { stdio: "ignore" });
+  child.unref();
+  return child;
+}
+
+function pgrepPids(pattern) {
+  return new Promise((resolve) => {
+    const proc = spawn("/usr/bin/pgrep", ["-f", pattern], { stdio: ["ignore", "pipe", "ignore"] });
+    let out = "";
+    proc.stdout.on("data", (d) => (out += d.toString()));
+    // pgrep exits 1 on no match, which is an answer, not an error.
+    proc.on("close", () =>
+      resolve(
+        out
+          .split("\n")
+          .map((line) => parseInt(line.trim(), 10))
+          .filter((n) => Number.isFinite(n) && n > 0),
+      ),
+    );
+    proc.on("error", () => resolve([]));
+  });
+}
+
+onMac("HELPER_PROC_MARKER against a real pgrep", () => {
+  /** @type {{children: import("node:child_process").ChildProcess[], dirs: string[]}} */
+  const spawned = { children: [], dirs: [] };
+
+  afterEach(() => {
+    for (const child of spawned.children) {
+      try {
+        child.kill("SIGKILL");
+      } catch {}
+    }
+    for (const dir of spawned.dirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    spawned.children = [];
+    spawned.dirs = [];
+  });
+
+  /** Build a fake bundle tree and return the paths the two layouts run as. */
+  function fakeBundle() {
+    const root = mkdtempSync(join(tmpdir(), "pimhelper-proc-"));
+    spawned.dirs.push(root);
+    const app = join(root, "PIMHelper.app");
+    mkdirSync(join(app, "Contents", "MacOS"), { recursive: true });
+    mkdirSync(join(app, "Contents", "Resources"), { recursive: true });
+    return {
+      app,
+      // What helper/launcher.c actually execv()s: its own directory plus
+      // "/../Resources/pim-helper.sh", never normalized. The literal ".." is the reason the
+      // old marker missed.
+      launcherLayout: join(app, "Contents", "MacOS", "..", "Resources", "pim-helper.sh"),
+      // Bundles installed before the launcher change, still in the wild.
+      preLauncherLayout: join(app, "Contents", "MacOS", "pim-helper"),
+    };
+  }
+
+  it("matches the launcher layout, whose path the old literal missed", async () => {
+    const bundle = fakeBundle();
+    expect(bundle.launcherLayout).not.toContain("Contents/MacOS/pim-helper");
+
+    const child = spawnWithArgv(bundle.launcherLayout);
+    spawned.children.push(child);
+
+    expect(await pgrepPids(HELPER_PROC_MARKER)).toContain(child.pid);
+  });
+
+  it("still matches pre-launcher bundles", async () => {
+    const bundle = fakeBundle();
+    const child = spawnWithArgv(bundle.preLauncherLayout);
+    spawned.children.push(child);
+
+    expect(await pgrepPids(HELPER_PROC_MARKER)).toContain(child.pid);
+  });
+
+  // The one that makes the widening safe. reapStaleHelpers() escalates to SIGKILL, so a
+  // pattern that caught the `open -W -a ... PIMHelper.app --args <cli> <out> <err>` parent
+  // would abort live calls instead of clearing wedged ones.
+  it("does not match the `open` parent, which names the bundle but never enters it", async () => {
+    const bundle = fakeBundle();
+    const decoy = join(bundle.app, "Contents", "Resources", "not-the-helper.sh");
+    const child = spawnWithArgv(decoy, [
+      "-W",
+      "-a",
+      bundle.app,
+      "--args",
+      "calendar-cli",
+      "/tmp/out",
+      "/tmp/err",
+      "list",
+    ]);
+    spawned.children.push(child);
+
+    // The decoy carries the whole `open` argv, and the bundle path, and "Contents/" -- it is
+    // excluded on the one thing that actually distinguishes the parent: nothing in its argv
+    // reads as a pim-helper inside the bundle.
+    const matched = await pgrepPids(HELPER_PROC_MARKER);
+    expect(matched).not.toContain(child.pid);
+    // Proves the decoy is genuinely running and merely unmatched, so a spawn failure cannot
+    // pass this test by accident.
+    expect(await pgrepPids("not-the-helper\\.sh")).toContain(child.pid);
+  });
+
+  it("findHelperProcesses reports the launcher-layout process with an age", async () => {
+    const bundle = fakeBundle();
+    const child = spawnWithArgv(bundle.launcherLayout);
+    spawned.children.push(child);
+
+    const found = await findHelperProcesses();
+    const mine = found.find((proc) => proc.pid === child.pid);
+    expect(mine, "findHelperProcesses() saw the resident dispatcher").toBeDefined();
+    // reapStaleHelpers() skips anything whose age is null, so a found-but-ageless process
+    // would still be unreapable.
+    expect(mine.ageSeconds).toBeTypeOf("number");
+  });
+});

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -61,9 +61,10 @@ pane() {
 # before matched nothing, and every helper-process check silently passed.
 # This pattern matches both layouts and does not match the `open -W -a
 # .../PIMHelper.app` parent, whose argv carries no "Contents/".
-# NOTE: lib/cli-runner.js and openclaw/lib/cli-runner.js (line 191, identical
-# copies) still carry the old literal marker, so reapStaleHelpers() there is
-# equally blind. Fixing that touches the auto-kill path and is left separate.
+# lib/cli-runner.js exports the same pattern as HELPER_PROC_MARKER for
+# reapStaleHelpers(). The two are independent copies in different languages;
+# mcp-server/test/cli-runner-helper-proc.test.js pins the JS one against a real
+# pgrep, including that it does not match the `open` parent.
 HELPER_PROC_MARKER='PIMHelper\.app/Contents/.*pim-helper'
 
 helper_resident() { pgrep -f "$HELPER_PROC_MARKER" >/dev/null 2>&1; }


### PR DESCRIPTION
Closes #123.

## The bug, confirmed

`findHelperProcesses()` searched for the literal `PIMHelper.app/Contents/MacOS/pim-helper`. That is no longer what the helper runs as. `helper/launcher.c` builds the dispatcher path as its own directory plus `"/../Resources/pim-helper.sh"` and **never normalizes it**, so the resident process command line is:

```
/bin/zsh ~/Applications/PIMHelper.app/Contents/MacOS/../Resources/pim-helper.sh ...
```

`Contents/MacOS/` is there. `Contents/MacOS/pim-helper` is not. `pgrep -f` matched nothing, so `findHelperProcesses()` always returned empty and `reapStaleHelpers()` was silently a no-op — against exactly the -1712 wedge it exists to clear. The self-healing path `commands/authorize.md` advertises never ran.

## The fix

Ports the pattern #120 already landed in `scripts/doctor.sh`:

```js
export const HELPER_PROC_MARKER = "PIMHelper\\.app/Contents/.*pim-helper";
```

Matches the launcher layout and the pre-launcher bundles still installed in the wild. Both copies of the file are covered: `openclaw/lib` is a symlink to `../lib`, verified still intact after the change.

## Testing the widening, since it feeds a SIGKILL

#123 asks for a test that the pattern does not match the `open` parent before it ships. A JS regex mirroring the pattern would not be that test — BSD `pgrep -f` applies its own extended-regex engine to the joined argv, and that engine is the thing being trusted. So `mcp-server/test/cli-runner-helper-proc.test.js` spawns processes carrying each real argv shape and runs the real `/usr/bin/pgrep`:

| Test | Asserts |
|---|---|
| launcher layout | matched (this is the case the old literal missed) |
| pre-launcher layout | still matched |
| the `open` parent | **not** matched |
| `findHelperProcesses()` | returns the pid *and* a numeric `ageSeconds` — a found-but-ageless process is still unreapable |

The `open`-parent decoy carries the full `open -W -a <bundle> --args ...` argv, the bundle path, and `Contents/`, so it is excluded on the one thing that actually distinguishes the parent. A second `pgrep` in that test proves the decoy is genuinely running, so a failed spawn cannot pass it by accident. Assertions are membership, never set equality, so a developer machine with a real PIMHelper resident does not break the suite. macOS-gated via `describe.skip`; the `MCP Server (Node)` job runs on `macos-latest` and its path filter includes `lib/**` and `mcp-server/**`, so this change triggers it.

Negative control against the old literal:

```
× matches the launcher layout, whose path the old literal missed
✓ still matches pre-launcher bundles
✓ does not match the `open` parent
× findHelperProcesses reports the launcher-layout process with an age
Tests  2 failed | 2 passed (4)
```

As committed: 90/90 across the whole `mcp-server` suite.

Also drops the now-stale `NOTE:` in `scripts/doctor.sh` that pointed at this exact gap, and replaces it with a pointer to the test.

Nothing here releases, tags, or publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDD6P9ft7DNNbrXpNWvCsk