### PR TITLE
fix(mail): refuse an ambiguous account under --engine jxa too

### DIFF
--- a/skills/apple-pim/references/mail-jxa.md
+++ b/skills/apple-pim/references/mail-jxa.md
@@ -18,6 +18,14 @@ row-id, so JXA can address it directly instead of scanning mailbox by mailbox,
 and they fall back to that scan whenever the lookup cannot answer. `send` and
 `reply` are unaffected.
 
+An `--account` hint that matches two accounts is **refused**, not resolved, under every
+engine. Both would otherwise pick a first match: the Envelope Index returns a set, and
+`Mail.accounts.whose({name:})` returns them in enumeration order. Acting on either is a
+silent wrong-account read, and a wrong-account write is not reversible. The two engines word
+the refusal differently on purpose — the index can suggest an account UUID because it can
+resolve one, and JXA resolves nothing but a name, so it says to rename the account in Mail
+or re-run under `--engine auto`.
+
 ## Why JXA?
 
 Mail.app has no native Swift framework (unlike EventKit/Contacts). JXA (JavaScript for Automation) provides:

--- a/swift/Sources/MailCLI/AccountAmbiguity.swift
+++ b/swift/Sources/MailCLI/AccountAmbiguity.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// The account-ambiguity refusal, in the two places it can be detected.
+///
+/// One account name spanning two accounts has to be refused rather than resolved, because
+/// every resolution available is arbitrary: the Envelope Index returns a set, and Mail's
+/// `whose({name:})` returns them in enumeration order. Acting on "whichever comes first" is
+/// the silent wrong-account read the check exists to prevent, and it is worse for writes,
+/// which are not reversible from here.
+///
+/// Until now only ONE of the two detectors existed. `EnvelopeIndex.accountUUIDs(matching:)`
+/// needs the Envelope Index, and `--engine jxa` opens no database by contract, so under that
+/// engine the check simply did not run and the hint fell through to first-match — for reads
+/// and writes alike. This type holds the second detector, which needs no database at all:
+/// `Mail.accounts.whose({name: hint})()` returning more than one result IS the ambiguity.
+///
+/// Both messages live here so the refusal is authored once, and so the JXA one can say
+/// something true. They are deliberately NOT the same string: the index can suggest an
+/// account UUID because it can resolve one, and JXA cannot resolve anything but a name.
+enum AccountAmbiguity {
+    /// Prefix on the JS `Error` the helper throws, so `runJXA` can tell this refusal apart
+    /// from a genuine script failure. Not user-facing; stripped before the message surfaces.
+    static let jxaMarker = "APPLE_PIM_ACCOUNT_AMBIGUOUS:"
+
+    /// The Envelope Index refusal. Unchanged wording: it is asserted by
+    /// `EnvelopeIndexAccountTests` and `EngineFallbackTests`, and the advice is sound there
+    /// because that path really can resolve a UUID.
+    static func envelopeIndexMessage(requestedName: String) -> String {
+        "Account matches multiple logical accounts: \(requestedName). "
+            + "Use the display name or account UUID instead."
+    }
+
+    /// JS helper resolving an account hint, refusing rather than picking a first match.
+    ///
+    /// Emitted as a function DECLARATION so hoisting makes placement in the generated script
+    /// irrelevant — several scripts call it from a helper defined above the point it is
+    /// interpolated. `mailApp` is a parameter rather than a closed-over `Mail` so the
+    /// declaration is position-independent in scripts that build `const Mail` themselves.
+    ///
+    /// A hint matching nothing returns the empty array, exactly as the expression it
+    /// replaces did: "no such account" is each call site's own error to report, and several
+    /// already word it their own way.
+    static func jxaHelperSource() -> String {
+        """
+        function resolveAccountsByHint(mailApp, hint) {
+            if (!hint) return mailApp.accounts();
+            const matched = mailApp.accounts.whose({name: hint})();
+            if (matched.length > 1) {
+                throw new Error('\(jxaMarker)Account name matches ' + matched.length
+                    + ' accounts in Mail: ' + hint
+                    + '. Mail resolves accounts by name here, so there is nothing to'
+                    + ' disambiguate with: rename one of them in Mail, or use --engine auto'
+                    + ' to select by account UUID.');
+            }
+            return matched;
+        }
+        """
+    }
+
+    /// Recover the refusal from osascript's stderr, or nil when this was some other failure.
+    ///
+    /// osascript wraps an uncaught throw as
+    /// `execution error: Error: Error: <message> (-2700)`, so both the prefix and the
+    /// trailing error number have to come off. The number is stripped only when it is the
+    /// last thing on the line, and every message this builds ends in prose, so an account
+    /// name that happens to contain parentheses is not at risk.
+    static func messageFromJXAStderr(_ stderr: String) -> String? {
+        guard let markerRange = stderr.range(of: jxaMarker) else { return nil }
+        var message = String(stderr[markerRange.upperBound...])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trailing = message.range(of: #" \(-?\d+\)$"#, options: .regularExpression) {
+            message.removeSubrange(trailing)
+        }
+        return message.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/swift/Sources/MailCLI/EnvelopeIndex.swift
+++ b/swift/Sources/MailCLI/EnvelopeIndex.swift
@@ -302,8 +302,7 @@ final class EnvelopeIndex {
         let logicalAccountIDs = Set(matches.compactMap { metadata[$0]?.logicalAccountID })
         guard logicalAccountIDs.count <= 1 else {
             throw EnvelopeIndexError.ambiguous(
-                "Account matches multiple logical accounts: \(requestedName). "
-                + "Use the display name or account UUID instead.")
+                AccountAmbiguity.envelopeIndexMessage(requestedName: requestedName))
         }
         return matches.sorted()
     }

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -495,6 +495,23 @@ func runJXA(_ script: String) throws -> Any {
     let stderrStr = String(data: stderrData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
     guard proc.terminationStatus == 0 else {
+        // The account-ambiguity refusal, raised by `resolveAccountsByHint` inside the script.
+        //
+        // Intercepted here rather than at each call site because every one of the ~12
+        // generated scripts that resolves an account hint reaches the user through this one
+        // function, and their result shapes do not agree: two return a Mail message object
+        // with no error channel at all, `search` returns a bare array, and the rest return
+        // `{error:}` mapped to `CLIError.notFound`. A thrown JS Error needs none of that, and
+        // it cannot be dropped by a call site that forgot to look. Every `runJXA(...)` in
+        // this file is a plain `try` with no `try?` and no swallowing catch, so this refusal
+        // reaches the caller from all of them.
+        //
+        // `invalidInput` for the same reason `rethrowFatalFastPathError` uses it on the
+        // SQLite side: ambiguity describes the caller's input, not the engine. Same exit
+        // code, same `Error: ` prefix, so the two engines now refuse identically.
+        if let ambiguity = AccountAmbiguity.messageFromJXAStderr(stderrStr) {
+            throw CLIError.invalidInput(ambiguity)
+        }
         if stderrStr.contains("not allowed to send keystrokes") || stderrStr.contains("not allowed assistive access") {
             throw CLIError.accessDenied("Grant access in System Settings > Privacy & Security > Automation")
         }
@@ -524,6 +541,8 @@ func findMessageJXA(targetId: String, mailbox: String?, account: String?) -> Str
     let accountFilter = account.map { "'\(escapeForJXA($0))'" } ?? "null"
 
     return """
+    \(AccountAmbiguity.jxaHelperSource())
+
     function findMessage() {
         const Mail = Application("Mail");
         const targetId = '\(escapedId)';
@@ -544,7 +563,7 @@ func findMessageJXA(targetId: String, mailbox: String?, account: String?) -> Str
             'Archive', 'All Mail', 'Drafts',
             'Deleted Messages', 'Deleted Items', 'Trash',
             'Junk', 'Junk Email', 'Junk E-mail', 'Bulk', 'Spam'];
-        const accounts = acctHint ? Mail.accounts.whose({name: acctHint})() : Mail.accounts();
+        const accounts = resolveAccountsByHint(Mail, acctHint);
         const searched = new Set();
 
         // If mailbox hint given, try it first (optimization, not a hard filter)
@@ -665,6 +684,8 @@ func generateUnifiedFindMsgJXA(rowidMapJS: String, backend: String,
     let debugMode = debug
 
     return """
+    \(AccountAmbiguity.jxaHelperSource())
+
     const rowidMap = \(rowidMapJS);
     const mboxHint = \(mailboxFilter);
     const acctHint = \(accountFilter);
@@ -702,6 +723,12 @@ func generateUnifiedFindMsgJXA(rowidMapJS: String, backend: String,
     // did not resolve — the candidate's UUID comes from Mail's own accounts database while
     // this arm matches against JXA's `account.id()`, and the account NAME is the fallback for
     // any Mail version where those two do not agree.
+    // Deliberately NOT routed through resolveAccountsByHint. `name` is not a user hint: it
+    // is the Envelope Index's own display name for a rowid candidate, read back out of
+    // rowidMap. Refusing here would fail a write over an ambiguity in data this code
+    // produced, and returning null on a miss is load-bearing -- the caller must fall through
+    // to the `whose` scan, which can still complete the write. (Under --engine jxa rowidMap
+    // is always empty, so this is unreachable in the mode the ambiguity gap was about.)
     function getAccountByName(name) {
         var matches = [];
         try { matches = Mail.accounts.whose({name: name})(); } catch(e) { return null; }
@@ -790,7 +817,7 @@ func generateUnifiedFindMsgJXA(rowidMapJS: String, backend: String,
         }
 
         lookup.method = 'whose';
-        var accounts = acctHint ? Mail.accounts.whose({name: acctHint})() : Mail.accounts();
+        var accounts = resolveAccountsByHint(Mail, acctHint);
         var searched = new Set();
 
         if (mboxHint) {
@@ -957,6 +984,8 @@ struct ListMailboxes: AsyncParsableCommand {
 
         let script = """
         const Mail = Application("Mail");
+        \(AccountAmbiguity.jxaHelperSource())
+
         const accountFilter = \(accountFilter);
         const results = [];
 
@@ -973,7 +1002,7 @@ struct ListMailboxes: AsyncParsableCommand {
         }
 
         if (accountFilter) {
-            const accts = Mail.accounts.whose({name: accountFilter})();
+            const accts = resolveAccountsByHint(Mail, accountFilter);
             if (accts.length === 0) {
                 JSON.stringify({error: "Account not found: " + accountFilter});
             } else {
@@ -1070,15 +1099,15 @@ struct ListMessages: AsyncParsableCommand {
 
         let script = """
         const Mail = Application("Mail");
+        \(AccountAmbiguity.jxaHelperSource())
+
         const accountFilter = \(accountFilter);
         const mailboxName = '\(mailboxName)';
         const limit = \(limit);
         const filterType = \(filterVal);
 
         function findMailbox() {
-            const accounts = accountFilter
-                ? Mail.accounts.whose({name: accountFilter})()
-                : Mail.accounts();
+            const accounts = resolveAccountsByHint(Mail, accountFilter);
             for (let a = 0; a < accounts.length; a++) {
                 const mbs = accounts[a].mailboxes.whose({name: mailboxName})();
                 if (mbs.length > 0) return mbs[0];
@@ -1347,6 +1376,8 @@ struct SearchMessages: AsyncParsableCommand {
 
         let script = """
         const Mail = Application("Mail");
+        \(AccountAmbiguity.jxaHelperSource())
+
         const query = '\(escapedQuery)';
         const searchField = '\(escapedField)';
         const accountFilter = \(accountFilter);
@@ -1404,9 +1435,7 @@ struct SearchMessages: AsyncParsableCommand {
             }
         }
 
-        const accounts = accountFilter
-            ? Mail.accounts.whose({name: accountFilter})()
-            : Mail.accounts();
+        const accounts = resolveAccountsByHint(Mail, accountFilter);
 
         for (let a = 0; a < accounts.length && results.length < limit; a++) {
             const acct = accounts[a];
@@ -1568,7 +1597,7 @@ struct MoveMessage: AsyncParsableCommand {
 
         function findDestMailbox(sourceAccount) {
             const accounts = destAccountName
-                ? Mail.accounts.whose({name: destAccountName})()
+                ? resolveAccountsByHint(Mail, destAccountName)
                 : [sourceAccount];
             for (let a = 0; a < accounts.length; a++) {
                 const mbs = accounts[a].mailboxes.whose({name: destMailboxName})();

--- a/swift/Sources/MailCLI/MessageLocator.swift
+++ b/swift/Sources/MailCLI/MessageLocator.swift
@@ -76,16 +76,14 @@ struct NoopLocator: MessageLocator {
 /// - `auto`: locator when one can be opened, silently Noop otherwise.
 /// - `sqlite`: locator required; an open failure is reported to the caller.
 ///
-/// KNOWN GAP, and the reason it is stated here rather than left to be rediscovered: the
-/// account-ambiguity refusal `SQLiteEngine.resolve` raises needs the Envelope Index to see
-/// that a name spans two logical accounts, so the `.jxa` arm above — which opens no database
-/// by contract — cannot raise it, and an ambiguous hint falls through to the JXA scan's
-/// first-match resolution. This is NOT the read/write split: every read command guards its
-/// fast path with the same `engine != .jxa`, so `--engine jxa` skips the check for reads
-/// exactly as it does for writes. Closing it means either opening the index under `--engine
-/// jxa` (breaking the contract, and unavailable anyway without Full Disk Access) or teaching
-/// the JXA sites to treat a multi-result `Mail.accounts.whose({name:})` as ambiguous.
-/// Tracked separately rather than changed here.
+/// The account-ambiguity refusal is NOT part of what the `.jxa` arm gives up, though it was
+/// once. `SQLiteEngine.resolve` raises it by asking the Envelope Index whether a name spans
+/// two logical accounts, which the `.jxa` arm cannot do — it opens no database by contract —
+/// so an ambiguous hint used to fall through to the JXA scan's first-match resolution, for
+/// reads and writes alike. It is now detected on the JXA side instead, with no database:
+/// `resolveAccountsByHint` (AccountAmbiguity.swift) treats a multi-result
+/// `Mail.accounts.whose({name:})` as the ambiguity it is and refuses. Both engines therefore
+/// refuse the same input, as `rethrowFatalFastPathError` has always claimed they should.
 func makeMessageLocator(engine: EngineChoice) throws -> MessageLocator {
     guard engine != .jxa else { return NoopLocator() }
     do {

--- a/swift/Tests/MailCLITests/AccountAmbiguityTests.swift
+++ b/swift/Tests/MailCLITests/AccountAmbiguityTests.swift
@@ -1,0 +1,214 @@
+import XCTest
+@testable import MailCLI
+
+/// The JXA half of the account-ambiguity refusal (#119).
+///
+/// These EXECUTE the shipped JS. That is possible without breaking the rule the rest of the
+/// suite works under — "running osascript against Mail.app is off limits in the build
+/// environment" — because `resolveAccountsByHint` takes the application as a parameter
+/// rather than closing over `Mail`. So the tests hand it a plain JS object, and osascript
+/// runs pure JavaScript with no `Application("Mail")` anywhere and no automation permission
+/// involved.
+///
+/// That is worth the extra machinery here specifically. A string-shape assertion could pin
+/// that the helper is emitted; it could not pin that it refuses, and refusing is the change.
+final class AccountAmbiguityTests: XCTestCase {
+
+    // MARK: - Running the emitted helper
+
+    /// Stand-in for `Application("Mail")`: `accounts` is callable AND carries `.whose`,
+    /// which is the shape the helper actually uses.
+    private static func fakeMailApp(_ names: [String]) -> String {
+        let list = names.map { "'\($0)'" }.joined(separator: ", ")
+        return """
+        (function () {
+            const names = [\(list)];
+            const accounts = function () { return names.map(function (n) { return {name: n}; }); };
+            accounts.whose = function (pred) {
+                return function () {
+                    return names.filter(function (n) { return n === pred.name; })
+                                .map(function (n) { return {name: n}; });
+                };
+            };
+            return {accounts: accounts};
+        })()
+        """
+    }
+
+    private struct JXARun {
+        let stdout: String
+        let stderr: String
+        let status: Int32
+    }
+
+    /// Run the emitted helper plus one expression through osascript.
+    private func runHelper(accounts: [String], hint: String?) throws -> JXARun {
+        let hintLiteral = hint.map { "'\($0)'" } ?? "null"
+        let script = """
+        \(AccountAmbiguity.jxaHelperSource())
+
+        JSON.stringify(
+            resolveAccountsByHint(\(Self.fakeMailApp(accounts)), \(hintLiteral))
+                .map(function (a) { return a.name; })
+        );
+        """
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        proc.arguments = ["-l", "JavaScript", "-e", script]
+        let out = Pipe(), err = Pipe()
+        proc.standardOutput = out
+        proc.standardError = err
+        try proc.run()
+        // Read before waiting: these outputs are tiny, but the pipe-deadlock shape is the
+        // same one runJXA documents, and copying the safe order costs nothing.
+        let outData = out.fileHandleForReading.readDataToEndOfFile()
+        let errData = err.fileHandleForReading.readDataToEndOfFile()
+        proc.waitUntilExit()
+        return JXARun(
+            stdout: String(decoding: outData, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            stderr: String(decoding: errData, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            status: proc.terminationStatus)
+    }
+
+    func testAUniqueAccountNameStillResolves() throws {
+        let run = try runHelper(accounts: ["Work", "Home"], hint: "Work")
+        XCTAssertEqual(run.status, 0, run.stderr)
+        XCTAssertEqual(run.stdout, "[\"Work\"]")
+    }
+
+    func testNoHintStillEnumeratesEveryAccount() throws {
+        let run = try runHelper(accounts: ["Work", "Home"], hint: nil)
+        XCTAssertEqual(run.status, 0, run.stderr)
+        XCTAssertEqual(run.stdout, "[\"Work\",\"Home\"]")
+    }
+
+    /// A hint matching nothing is each call site's own "Account not found", not this
+    /// helper's error. Several sites word that message themselves and must keep doing so.
+    func testAHintThatMatchesNothingIsNotAnAmbiguityError() throws {
+        let run = try runHelper(accounts: ["Work", "Home"], hint: "Nope")
+        XCTAssertEqual(run.status, 0, run.stderr)
+        XCTAssertEqual(run.stdout, "[]")
+    }
+
+    /// The bug in #119: two accounts sharing a display name resolved to whichever enumerated
+    /// first. It now refuses, with no database open anywhere.
+    func testAnAmbiguousAccountNameRefusesInsteadOfPickingTheFirst() throws {
+        let run = try runHelper(accounts: ["Shared", "Shared"], hint: "Shared")
+        XCTAssertNotEqual(run.status, 0, "an ambiguous hint must not resolve")
+        XCTAssertTrue(run.stderr.contains(AccountAmbiguity.jxaMarker),
+                      "stderr must carry the marker runJXA keys on: \(run.stderr)")
+        XCTAssertFalse(run.stdout.contains("Shared"),
+                       "nothing may be returned for an ambiguous hint: \(run.stdout)")
+    }
+
+    /// End to end across the seam: real osascript wrapping, real stderr, real parser. This is
+    /// what proves `runJXA` turns the thrown Error into the refusal the user sees, rather
+    /// than into a generic `CLIError.jxaError` carrying a marker nobody stripped.
+    func testTheThrownErrorSurvivesOsascriptWrappingAndParsesBackToAMessage() throws {
+        let run = try runHelper(accounts: ["Shared", "Shared"], hint: "Shared")
+
+        guard let message = AccountAmbiguity.messageFromJXAStderr(run.stderr) else {
+            return XCTFail("parser did not recognize its own marker in: \(run.stderr)")
+        }
+        XCTAssertTrue(message.hasPrefix("Account name matches 2 accounts in Mail: Shared"),
+                      "message was: \(message)")
+        XCTAssertFalse(message.contains(AccountAmbiguity.jxaMarker), "marker must be stripped")
+        // osascript appends " (-2700)"; a user-facing message must not end in an OSA code.
+        XCTAssertFalse(message.hasSuffix(")"), "trailing error number must be stripped: \(message)")
+        XCTAssertTrue(message.contains("--engine auto"), "must name a remedy that exists")
+    }
+
+    // MARK: - The stderr parser on its own
+
+    func testParserIgnoresUnrelatedFailures() {
+        XCTAssertNil(AccountAmbiguity.messageFromJXAStderr(
+            "execution error: Error: Mail got an error: Can't get account 1. (-1728)"))
+        XCTAssertNil(AccountAmbiguity.messageFromJXAStderr(""))
+    }
+
+    /// Only a trailing OSA code comes off. An account name with parentheses in it must not
+    /// be truncated by the same rule.
+    func testParserStripsOnlyATrailingErrorNumber() {
+        let stderr = "execution error: Error: Error: "
+            + AccountAmbiguity.jxaMarker
+            + "Account name matches 2 accounts in Mail: Work (old). Rename one. (-2700)"
+        XCTAssertEqual(
+            AccountAmbiguity.messageFromJXAStderr(stderr),
+            "Account name matches 2 accounts in Mail: Work (old). Rename one.")
+    }
+
+    // MARK: - Both engines refuse, and say something true
+
+    /// The two refusals are deliberately worded differently, and the JXA one must not repeat
+    /// the index's advice: under JXA a hint is matched against the display name, so "use the
+    /// display name" is exactly the thing that already failed, and no UUID can be resolved.
+    func testTheJXARefusalDoesNotRepeatAdviceThatCannotWorkThere() throws {
+        let indexMessage = AccountAmbiguity.envelopeIndexMessage(requestedName: "Shared")
+        XCTAssertEqual(indexMessage,
+                       "Account matches multiple logical accounts: Shared. "
+                       + "Use the display name or account UUID instead.")
+
+        let run = try runHelper(accounts: ["Shared", "Shared"], hint: "Shared")
+        let jxaMessage = try XCTUnwrap(AccountAmbiguity.messageFromJXAStderr(run.stderr))
+        XCTAssertNotEqual(jxaMessage, indexMessage)
+        XCTAssertFalse(jxaMessage.contains("Use the display name"))
+    }
+}
+
+/// Which emitted scripts route their account hint through the refusal.
+///
+/// Shape assertions, unlike the tests above, because these pin WIRING: that no generator
+/// quietly keeps a raw first-match resolution. A site that regresses stops appearing here.
+final class AccountAmbiguityWiringTests: XCTestCase {
+
+    /// The raw expression the fix replaces. Its only surviving use is `getAccountByName`,
+    /// which resolves a name this code produced rather than one the user typed.
+    private let rawResolution = "Mail.accounts.whose({name:"
+
+    func testTheReadPathFinderResolvesThroughTheRefusal() {
+        let script = findMessageJXA(targetId: "<m@x>", mailbox: nil, account: "Shared")
+        XCTAssertTrue(script.contains("function resolveAccountsByHint(mailApp, hint)"),
+                      "the helper must travel with the script that calls it")
+        XCTAssertTrue(script.contains("resolveAccountsByHint(Mail, acctHint)"))
+        XCTAssertFalse(script.contains(rawResolution),
+                       "the read path must not keep a first-match resolution")
+    }
+
+    func testTheWritePathFinderResolvesThroughTheRefusal() {
+        let script = generateUnifiedFindMsgJXA(
+            rowidMapJS: "{}", backend: "sqlite", mailbox: nil, account: "Shared")
+        XCTAssertTrue(script.contains("function resolveAccountsByHint(mailApp, hint)"))
+        XCTAssertTrue(script.contains("resolveAccountsByHint(Mail, acctHint)"))
+        // Exactly one raw resolution survives, and it is the deliberate exclusion.
+        XCTAssertEqual(script.components(separatedBy: rawResolution).count - 1, 1,
+                       "only getAccountByName may resolve a name without refusing")
+        XCTAssertTrue(script.contains("function getAccountByName(name)"))
+    }
+
+    /// #119 calls out that this is not a read/write split, so pin that it is closed on both
+    /// sides at once. The two finders are independently generated and have drifted before.
+    func testBothShippedFindersRefuseAmbiguityTheSameWay() {
+        let read = findMessageJXA(targetId: "<m@x>", mailbox: nil, account: "Shared")
+        let write = generateUnifiedFindMsgJXA(
+            rowidMapJS: "{}", backend: "sqlite", mailbox: nil, account: "Shared")
+        for script in [read, write] {
+            XCTAssertTrue(script.contains(AccountAmbiguity.jxaMarker),
+                          "both finders must carry the same refusal marker")
+        }
+    }
+
+    func testTheMoveDestinationAccountHintAlsoRefuses() {
+        let script = MoveMessage.buildScript(
+            id: "<m@x>", toMailbox: "Archive", toAccount: "Shared",
+            findHelper: generateUnifiedFindMsgJXA(
+                rowidMapJS: "{}", backend: "sqlite", mailbox: nil, account: nil))
+        // `--to-account` is a second, independent hint on the same command; the source
+        // account travels through the finder above.
+        XCTAssertTrue(script.contains("resolveAccountsByHint(Mail, destAccountName)"))
+        XCTAssertTrue(script.contains("function resolveAccountsByHint(mailApp, hint)"),
+                      "the finder must bring the helper into this script")
+    }
+}

--- a/swift/Tests/MailCLITests/AccountAmbiguityTests.swift
+++ b/swift/Tests/MailCLITests/AccountAmbiguityTests.swift
@@ -212,3 +212,79 @@ final class AccountAmbiguityWiringTests: XCTestCase {
                       "the finder must bring the helper into this script")
     }
 }
+
+/// Does the generated JXA actually parse?
+///
+/// Nothing asked this before. The suite reads emitted scripts as strings and checks for
+/// substrings, which cannot tell a well-formed script from one a bad interpolation broke --
+/// and #119 edited seven of them. `osacompile` answers it without running anything: it
+/// compiles, never executes, so no Mail.app and no automation permission is involved. It
+/// reports a syntax error on stderr while still exiting 0, so stderr is the signal.
+final class GeneratedScriptSyntaxTests: XCTestCase {
+
+    /// Compile `js` and return the compiler's complaint, or nil when it parsed.
+    private func compilationError(_ js: String) throws -> String? {
+        let osacompile = URL(fileURLWithPath: "/usr/bin/osacompile")
+        guard FileManager.default.isExecutableFile(atPath: osacompile.path) else {
+            throw XCTSkip("/usr/bin/osacompile unavailable")
+        }
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let source = dir.appendingPathComponent("script.js")
+        try js.write(to: source, atomically: true, encoding: .utf8)
+
+        let proc = Process()
+        proc.executableURL = osacompile
+        proc.arguments = ["-l", "JavaScript",
+                          "-o", dir.appendingPathComponent("out.scpt").path,
+                          source.path]
+        let err = Pipe()
+        proc.standardOutput = Pipe()
+        proc.standardError = err
+        try proc.run()
+        let data = err.fileHandleForReading.readDataToEndOfFile()
+        proc.waitUntilExit()
+        let message = String(decoding: data, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return message.isEmpty ? nil : message
+    }
+
+    /// Proves the check can fail, so a green run means something.
+    func testTheSyntaxCheckRejectsBrokenJavaScript() throws {
+        let error = try compilationError("function broken( { const x =")
+        XCTAssertNotNil(error, "osacompile must report a syntax error on malformed input")
+    }
+
+    func testTheHelperItselfParses() throws {
+        XCTAssertNil(try compilationError(AccountAmbiguity.jxaHelperSource()))
+    }
+
+    func testTheReadPathFinderParsesWithHintsAndWithout() throws {
+        for account in ["Shared 'quoted'", nil] {
+            let script = findMessageJXA(targetId: "<m'x@y>", mailbox: "Inbox \"A\"", account: account)
+            XCTAssertNil(try compilationError(script), "account hint: \(account ?? "nil")")
+        }
+    }
+
+    func testTheWritePathFinderParsesWithHintsAndWithout() throws {
+        for account in ["Shared 'quoted'", nil] {
+            let script = generateUnifiedFindMsgJXA(
+                rowidMapJS: "{\"a@b\":[{\"r\":7,\"acct\":\"X\"}]}", backend: "sqlite",
+                mailbox: "Inbox \"A\"", account: account)
+            XCTAssertNil(try compilationError(script), "account hint: \(account ?? "nil")")
+        }
+    }
+
+    /// The one command carrying two independent account hints, so the finder's copy of the
+    /// helper and the destination lookup's call to it appear in a single script.
+    func testTheMoveScriptParsesWithBothAccountHints() throws {
+        let script = MoveMessage.buildScript(
+            id: "<m'x@y>", toMailbox: "Archive \"2026\"", toAccount: "Shared 'quoted'",
+            findHelper: generateUnifiedFindMsgJXA(
+                rowidMapJS: "{}", backend: "jxa-only", mailbox: nil, account: "Shared 'quoted'"))
+        XCTAssertNil(try compilationError(script))
+    }
+}


### PR DESCRIPTION
Closes #119.

Swift-only, by necessity: the gap lives entirely in `swift/Sources/MailCLI/`. No Xcode, no signing, no release — `swift build` / `swift test` from the CLI only.

## The gap

`EnvelopeIndexError.ambiguous` was raised by exactly one detector, `EnvelopeIndex.accountUUIDs(matching:)`, which needs the Envelope Index. `--engine jxa` opens no database by contract, so the check never ran and the hint fell through to `Mail.accounts.whose({name: hint})()` — first match. Two accounts sharing a display name meant acting on whichever enumerated first. A wrong-account read, or a wrong-account `move`/`delete` that is not reversible from here.

Both options #119 lists were weighed, and it picks the right one. Opening the index under `--engine jxa` breaks the documented contract and is unavailable anyway in the case that engine most exists for (no Full Disk Access). Detecting it in JXA needs no database at all, and it makes ambiguity a property of the **input** rather than of the engine — which is what `rethrowFatalFastPathError`'s comment already claimed it was.

## The fix

New `AccountAmbiguity` holds both halves so the refusal is authored once: the Envelope Index message (wording unchanged — `EnvelopeIndexAccountTests` and `EngineFallbackTests` assert it) and a JXA helper that refuses instead of resolving.

```js
function resolveAccountsByHint(mailApp, hint) {
    if (!hint) return mailApp.accounts();
    const matched = mailApp.accounts.whose({name: hint})();
    if (matched.length > 1) { throw new Error('<marker>…'); }
    return matched;
}
```

Wired through all seven user-hint sites: both finder generators (`findMessageJXA`, `generateUnifiedFindMsgJXA` — 10 of the ~12 embeds between them), plus `mailboxes`, `messages`, `search`, and `move --to-account`.

`getAccountByName` is **deliberately** left resolving by first match, and now carries a comment saying why: its `name` is the Envelope Index's own display name for a rowid candidate, not user input, and returning null on a miss is load-bearing — the caller must fall through to the `whose` scan, which can still complete the write.

### Decoded in `runJXA`, not per call site

Every one of those scripts reaches the user through `runJXA`, and their result shapes do not agree: two return a Mail message object with **no error channel at all**, `search` returns a bare array with no channel either, and the rest return `{error:}` mapped to `CLIError.notFound`. A thrown JS Error needs none of that plumbing and cannot be dropped by a call site that forgot to look. Verified that every `runJXA(...)` in the file is a plain `try` with no `try?` and no swallowing `catch`, so the refusal reaches the caller from all fourteen.

It surfaces as `CLIError.invalidInput` — the same terminal form, exit code and `Error: ` prefix the SQLite path produces via `rethrowFatalFastPathError`.

### Two messages, on purpose

"Use the display name or account UUID instead" is sound advice from the index, which can resolve a UUID. Under JXA it is false twice over: the hint *is* matched against the display name, and no UUID resolves. The JXA refusal says to rename the account in Mail or re-run under `--engine auto`. A test pins that the two do not converge.

## Tests execute the shipped JS

The suite's standing rule is that running `osascript` against Mail.app is off limits in the build environment, so the existing JXA tests are string-shape assertions only. That would pin that the helper is *emitted* and not that it *refuses* — and refusing is the change.

Passing the application as a parameter rather than closing over `Mail` makes the helper runnable against a plain JS object, so these tests run real `osascript` on pure JavaScript with no `Application("Mail")` anywhere and no automation permission involved:

- a unique name still resolves; no hint still enumerates everything
- a hint matching nothing is **not** an ambiguity error (each call site keeps wording its own "Account not found")
- an ambiguous name refuses and returns nothing
- **end to end**: a real throw through real osascript wrapping (`execution error: Error: Error: … (-2700)`) and back out of `messageFromJXAStderr` — the seam that would otherwise only be reasoned about
- the parser ignores unrelated failures, and strips only a *trailing* OSA code, so an account name containing parentheses is not truncated

Plus wiring assertions that no generator quietly keeps a first-match resolution, including that exactly **one** raw `Mail.accounts.whose({name:` survives in the write finder and it is `getAccountByName`.

### The generated JXA is now compiled, not just grepped

Nothing previously asked whether the emitted scripts *parse*. The existing JXA tests read them as strings and assert substrings, which cannot distinguish a well-formed script from one a bad interpolation broke — and this branch edits seven of them.

`osacompile` answers that without the thing that made it untestable before: it compiles and never executes, so no Mail.app and no automation permission is involved. (It reports syntax errors on stderr while still exiting 0, so stderr is the signal; a negative-control test proves the check can fail.) Covers the helper, both finder generators with and without a hint, and the move script — the one command carrying two independent account hints, so the finder's copy of the helper and the destination lookup's call to it land in one script. Hints carry embedded quotes, so escaping is exercised.

The three inline scripts (`mailboxes`, `messages`, `search`) are built inside `run()` and unreachable from a test without a refactor. All six generated scripts — those three included — were compiled by hand the same way:

```
ok  MailCLI.swift:543   findMessageJXA
ok  MailCLI.swift:686   generateUnifiedFindMsgJXA
ok  MailCLI.swift:985   ListMailboxes
ok  MailCLI.swift:1100  ListMessages
ok  MailCLI.swift:1377  SearchMessages
ok  MailCLI.swift:1591  MoveMessage.buildScript
6 parsed cleanly, 0 failed
```

`swift test`: **177 tests, 0 failures** (was 160). The existing `testWriteCommandScriptsDeclareMailBeforeTheFinderHelper` and `testBothShippedFindersSweepAccountOuterNotPriorityOuter` still pass — the helper is emitted as a hoisted function declaration and takes its app as a parameter, so it is position-independent.

Also updates the `KNOWN GAP` paragraph on `makeMessageLocator`, which existed to keep this from being rediscovered, and adds a note to `skills/apple-pim/references/mail-jxa.md`.

Nothing here releases, tags, or publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDD6P9ft7DNNbrXpNWvCsk
