### PR TITLE
ci: fail the OpenClaw Plugin check when it cannot run the suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,10 +119,16 @@ jobs:
   # The job self-enabled on 2026-08-31 when openclaw@2026.8.1 hit npm -- the first
   # published release that both satisfies the plugin's declared floor and ships the
   # channel-ingress contract. The probe stays: it asserts the capability, not the
-  # version, so if a future published SDK regresses the contract this job goes back
-  # to skipping loudly instead of failing for the wrong reason.
+  # version, so a future SDK that regresses the contract is caught for the right
+  # reason rather than by a version comparison.
   #
-  # Eligible for required-check promotion once its summary has said "RAN" for a while.
+  # An unavailable contract now FAILS this job rather than skipping it green. That is
+  # a deliberate reversal: while nothing published shipped the contract, skipping was
+  # the honest answer and failing would have blocked every PR over an upstream gap
+  # nobody here could close. Now that one does ship it, and this job is a required
+  # check, a green skip is the exact failure mode #122 was filed about -- a check that
+  # reads as proof and ran nothing. The condition that made skipping right is gone, so
+  # the behaviour changes with it.
   openclaw-plugin-tests:
     name: OpenClaw Plugin
     runs-on: ubuntu-latest
@@ -140,27 +146,34 @@ jobs:
         id: sdk
         uses: ./.github/actions/openclaw-sdk-contract
 
-      - name: Skip, loudly, while no installable SDK ships the contract
+      - name: Fail when no installable SDK ships the contract
         if: steps.sdk.outputs.available != 'true'
         env:
           DETAIL: ${{ steps.sdk.outputs.detail }}
         run: |
-          echo "::notice::openclaw tests skipped -- $DETAIL"
           {
-            echo "### OpenClaw plugin tests: SKIPPED"
+            echo "### OpenClaw plugin tests: DID NOT RUN"
             echo ""
             echo "> $DETAIL"
             echo ""
-            echo "This job proves nothing in this run. It starts running by itself once a"
-            echo "published SDK ships the channel-ingress contract."
+            echo "This job proves nothing in this run, and it is a required check, so it"
+            echo "fails rather than reporting green on nothing."
+            echo ""
+            echo "The mail-channel ingress suite is the only thing standing between a"
+            echo "spoofed sender and an agent run, so \"could not check\" is not a pass."
+            echo "Expect this when the SDK the plugin's declared floor resolves to stops"
+            echo "shipping the channel-ingress contract, or when npm cannot be reached."
+            echo ""
+            echo "To unblock: fix the floor in openclaw/package.json, or wait for a"
+            echo "published SDK that satisfies it. Do not relax this job."
           } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::openclaw ingress suite did not run -- $DETAIL"
+          exit 1
 
       - name: Install root dependencies
-        if: steps.sdk.outputs.available == 'true'
         run: npm install
 
       - name: Install plugin dependencies
-        if: steps.sdk.outputs.available == 'true'
         working-directory: openclaw
         # apple-pim-cli declares "os": ["darwin"] (at runtime it spawns the four
         # macOS-only Swift CLIs), so a plain `npm install` refuses to run here with
@@ -170,12 +183,10 @@ jobs:
         run: npm install --force
 
       - name: Run OpenClaw plugin tests
-        if: steps.sdk.outputs.available == 'true'
         working-directory: openclaw
         run: npm test
 
       - name: Record that the suite actually ran
-        if: steps.sdk.outputs.available == 'true'
         env:
           VERSION: ${{ steps.sdk.outputs.version }}
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,11 @@ Each Swift CLI is a standalone binary that reads from macOS frameworks, validate
   - `MCP Server (Node)`
   - `Swift CLI`
   - `Version Consistency`
-  - `OpenClaw Plugin` (promoted 2026-09-01 after its first real runs against openclaw@2026.8.1)
+  - `OpenClaw Plugin` (promoted 2026-09-01 after its first real runs against openclaw@2026.8.1).
+    Runs the `openclaw/` suite -- the mail-channel ingress admission tests. It FAILS, rather
+    than skipping green, when its capability probe finds no published SDK shipping the
+    channel-ingress contract: a required check that ran nothing is the failure mode #122 was
+    filed about. Do not relax it to unblock a PR; fix the floor in `openclaw/package.json`.
 - Auto-merge is enabled at the repo level; use it on PRs so merges wait for required checks.
 - This repo ignores lockfiles; CI uses `npm install` (not `npm ci`) in `mcp-server`.
 - Agent evals run on `ubuntu-latest` (no macOS needed since they use mock fixtures).


### PR DESCRIPTION
Addresses the last live part of #122.

## What #122 asked for is already on `main`

Worth stating before the change, because it reframes the issue. #124 added the `OpenClaw Plugin` job with a capability probe, the probe self-enabled when `openclaw@2026.8.1` published as `latest`, and the check was promoted to required on `main` earlier today. Verified:

- `gh api .../branches/main/protection` → required contexts include `OpenClaw Plugin`
- CI run [33466124237](https://github.com/omarshahine/apple-pim/actions/runs/33466124237) on `main`: probe resolved `openclaw@2026.8.1`, suite **RAN**, 251 pass / 0 fail

So the suite is running and required. One hole is left.

## The hole

When the probe reports `available != 'true'`, the job prints a loud summary and **succeeds**. As a required check, that is a green tick on a run that executed nothing — the exact thing #122 was filed about:

> The checks were green because nothing ran them, not because they passed.

Skipping green was the right answer while no published SDK shipped the contract: failing would have blocked every PR over an upstream gap nobody in this repo could close. Both halves of that have changed. A published SDK ships it, and the job is now required. So the condition that made skipping right is gone, and the behaviour follows it.

The probe itself is untouched. It still asserts the capability rather than comparing versions, which is what keeps a future regression failing for the *right* reason rather than on a version string — the point its own comment makes about `2026.9.1-beta.1`.

## What the failure looks like

```
### OpenClaw plugin tests: DID NOT RUN

> no published openclaw release satisfies >=2026.8.1

This job proves nothing in this run, and it is a required check, so it
fails rather than reporting green on nothing.

The mail-channel ingress suite is the only thing standing between a
spoofed sender and an agent run, so "could not check" is not a pass.
Expect this when the SDK the plugin's declared floor resolves to stops
shipping the channel-ingress contract, or when npm cannot be reached.

To unblock: fix the floor in openclaw/package.json, or wait for a
published SDK that satisfies it. Do not relax this job.
```

Rendered by actually running the step's script with a stubbed `DETAIL` and `GITHUB_STEP_SUMMARY`; `bash -n` clean, exits 1.

The `if:` guards come off the remaining steps — once the probe failure is fatal, nothing after it is reachable with `available != 'true'`.

`AGENTS.md` records the behaviour next to the required-checks list, including "do not relax it to unblock a PR".

The publish workflows (`publish-npm`, `publish-clawhub`, `publish-homebrew`) use the same probe as a gate and are deliberately not touched. Nothing here releases, tags, or publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDD6P9ft7DNNbrXpNWvCsk