### PR TITLE
fix(mail): stop batch-update and batch-delete swallowing the ambiguity refusal

### DIFF
--- a/skills/apple-pim/references/mail-jxa.md
+++ b/skills/apple-pim/references/mail-jxa.md
@@ -19,12 +19,17 @@ and they fall back to that scan whenever the lookup cannot answer. `send` and
 `reply` are unaffected.
 
 An `--account` hint that matches two accounts is **refused**, not resolved, under every
-engine. Both would otherwise pick a first match: the Envelope Index returns a set, and
+engine, and for batch commands the whole run is refused rather than each entry. Both would otherwise pick a first match: the Envelope Index returns a set, and
 `Mail.accounts.whose({name:})` returns them in enumeration order. Acting on either is a
 silent wrong-account read, and a wrong-account write is not reversible. The two engines word
 the refusal differently on purpose — the index can suggest an account UUID because it can
 resolve one, and JXA resolves nothing but a name, so it says to rename the account in Mail
 or re-run under `--engine auto`.
+
+This covers account names *you* pass. Two names the CLI derives internally still resolve by
+first match: the write finder's row-id candidates, and the account `reply` reads back off the
+message it is answering. With two same-named accounts a reply can therefore still bind the
+wrong one and fail with "Could not locate the original message" instead of an ambiguity error.
 
 ## Why JXA?
 

--- a/swift/Sources/MailCLI/AccountAmbiguity.swift
+++ b/swift/Sources/MailCLI/AccountAmbiguity.swift
@@ -19,7 +19,8 @@ import Foundation
 /// account UUID because it can resolve one, and JXA cannot resolve anything but a name.
 enum AccountAmbiguity {
     /// Prefix on the JS `Error` the helper throws, so `runJXA` can tell this refusal apart
-    /// from a genuine script failure. Not user-facing; stripped before the message surfaces.
+    /// from a genuine script failure. Not user-facing: `runJXA` strips it from stderr on the
+    /// uncaught path and from stdout on the caught one, and refuses either way.
     static let jxaMarker = "APPLE_PIM_ACCOUNT_AMBIGUOUS:"
 
     /// The Envelope Index refusal. Unchanged wording: it is asserted by
@@ -40,6 +41,19 @@ enum AccountAmbiguity {
     /// A hint matching nothing returns the empty array, exactly as the expression it
     /// replaces did: "no such account" is each call site's own error to report, and several
     /// already word it their own way.
+    ///
+    /// `assertAccountHintResolvable` exists because a throw is only a refusal if nobody
+    /// catches it. `batch-update` and `batch-delete` wrap each entry's `findMsg()` in a JS
+    /// `try/catch` that records the error and continues, which swallowed this refusal
+    /// wholesale: osascript exited 0, `runJXA` never looked at stderr, and the marker below
+    /// was rendered to the user once per message id. Calling this once at SCRIPT TOP LEVEL,
+    /// outside every loop and every `try`, refuses before any message is touched -- which is
+    /// also the right semantics for a batch: an ambiguous scope invalidates the whole run,
+    /// not each entry separately.
+    ///
+    /// It is a separate function, and guarded on `hint`, so that the no-hint case stays as
+    /// lazy as it was: with no `--account` this does no work at all, rather than enumerating
+    /// every account up front on a path that may never need them.
     static func jxaHelperSource() -> String {
         """
         function resolveAccountsByHint(mailApp, hint) {
@@ -53,6 +67,10 @@ enum AccountAmbiguity {
                     + ' to select by account UUID.');
             }
             return matched;
+        }
+
+        function assertAccountHintResolvable(mailApp, hint) {
+            if (hint) { resolveAccountsByHint(mailApp, hint); }
         }
         """
     }
@@ -72,5 +90,35 @@ enum AccountAmbiguity {
             message.removeSubrange(trailing)
         }
         return message.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Recover the refusal from a script's *stdout*, or nil when it is not in there.
+    ///
+    /// The uncaught path puts it on stderr; this is the caught one, where a JS `catch` has
+    /// already folded it into the script's JSON result. `assertAccountHintResolvable` is what
+    /// stops that happening, and this is the backstop for if it ever happens again: it makes
+    /// "the marker never reaches a user" true by construction rather than by auditing every
+    /// `catch` block in every generated script.
+    ///
+    /// Reads to the first unescaped quote, because the marker sits inside a JSON string
+    /// value, then undoes JSON's two escapes so an account name containing a quote or a
+    /// backslash comes back as itself.
+    static func messageFromJXAOutput(_ stdout: String) -> String? {
+        guard let markerRange = stdout.range(of: jxaMarker) else { return nil }
+        var message = ""
+        var iterator = stdout[markerRange.upperBound...].makeIterator()
+        while let character = iterator.next() {
+            if character == "\\" {
+                // JSON escape: take the next character literally, mapping the two that can
+                // legally appear inside a message this code authored.
+                guard let escaped = iterator.next() else { break }
+                message.append(escaped == "n" ? "\n" : escaped)
+                continue
+            }
+            if character == "\"" { break }
+            message.append(character)
+        }
+        let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/swift/Sources/MailCLI/MailCLI.swift
+++ b/swift/Sources/MailCLI/MailCLI.swift
@@ -501,10 +501,17 @@ func runJXA(_ script: String) throws -> Any {
         // generated scripts that resolves an account hint reaches the user through this one
         // function, and their result shapes do not agree: two return a Mail message object
         // with no error channel at all, `search` returns a bare array, and the rest return
-        // `{error:}` mapped to `CLIError.notFound`. A thrown JS Error needs none of that, and
-        // it cannot be dropped by a call site that forgot to look. Every `runJXA(...)` in
-        // this file is a plain `try` with no `try?` and no swallowing catch, so this refusal
-        // reaches the caller from all of them.
+        // `{error:}` mapped to `CLIError.notFound`. A thrown JS Error needs none of that.
+        // Every `runJXA(...)` in this file is a plain `try` with no `try?` and no swallowing
+        // catch, so this refusal reaches the caller from all of them.
+        //
+        // What a thrown Error does NOT do by itself is survive a catch on the JS side. This
+        // comment used to claim it could not be dropped by a call site that forgot to look,
+        // and that was wrong: `batch-update` and `batch-delete` wrap each entry's `findMsg()`
+        // in a `try/catch`, which ate the refusal, exited 0, and rendered the marker to the
+        // user once per message id. `assertAccountHintResolvable`, called at script top level
+        // by the write finder, is the actual fix; the stdout check further down is the
+        // backstop that keeps the marker off a user's screen if it ever happens again.
         //
         // `invalidInput` for the same reason `rethrowFatalFastPathError` uses it on the
         // SQLite side: ambiguity describes the caller's input, not the engine. Same exit
@@ -519,6 +526,18 @@ func runJXA(_ script: String) throws -> Any {
     }
 
     let stdoutStr = String(data: stdoutData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+    // The refusal again, this time having been caught inside the script and folded into its
+    // JSON result, which exits 0 and never reaches the stderr branch above.
+    //
+    // `assertAccountHintResolvable` is what stops a script getting here, and this is the
+    // backstop for if one ever does. It is what makes "the marker is not user-facing" a
+    // property of this function rather than a claim about every `catch` block in every
+    // generated script -- which is exactly the claim that turned out to be false for
+    // `batch-update` and `batch-delete`, where the marker was rendered once per message id.
+    if let ambiguity = AccountAmbiguity.messageFromJXAOutput(stdoutStr) {
+        throw CLIError.invalidInput(ambiguity)
+    }
 
     guard !stdoutStr.isEmpty else {
         return [String: Any]()
@@ -689,6 +708,9 @@ func generateUnifiedFindMsgJXA(rowidMapJS: String, backend: String,
     const rowidMap = \(rowidMapJS);
     const mboxHint = \(mailboxFilter);
     const acctHint = \(accountFilter);
+    // Refuse an ambiguous --account here, at top level, before any command's per-entry
+    // try/catch can swallow it. `batch-update` and `batch-delete` wrap findMsg() in one.
+    assertAccountHintResolvable(Mail, acctHint);
     const MAILBOX_PRIORITY = \(mailboxPriorityJSON());
     const _locatorBackend = '\(backend)';
     const _debug = \(debugMode ? "true" : "false");

--- a/swift/Sources/MailCLI/MessageLocator.swift
+++ b/swift/Sources/MailCLI/MessageLocator.swift
@@ -83,7 +83,17 @@ struct NoopLocator: MessageLocator {
 /// reads and writes alike. It is now detected on the JXA side instead, with no database:
 /// `resolveAccountsByHint` (AccountAmbiguity.swift) treats a multi-result
 /// `Mail.accounts.whose({name:})` as the ambiguity it is and refuses. Both engines therefore
-/// refuse the same input, as `rethrowFatalFastPathError` has always claimed they should.
+/// refuse the same `--account`, as `rethrowFatalFastPathError` has always claimed they should.
+///
+/// Scoped to hints the CALLER supplied. Two account names the code derives for itself are
+/// deliberately still first-match, and neither is reachable from `--account`:
+/// `getAccountByName` in the write finder resolves the Envelope Index's own name for a rowid
+/// candidate, and `buildReplyAppleScript` emits `first account whose name is ...` for a name
+/// read back off the message it is replying to. The reply one is the weaker of the two: with
+/// two same-named accounts it can bind the wrong one and then fail its own lookup, surfacing
+/// as "Could not locate the original message" rather than as an ambiguity. Left alone because
+/// closing it means teaching the AppleScript reply path to address accounts by something
+/// other than name, which is a different change from this one.
 func makeMessageLocator(engine: EngineChoice) throws -> MessageLocator {
     guard engine != .jxa else { return NoopLocator() }
     do {

--- a/swift/Tests/MailCLITests/AccountAmbiguityTests.swift
+++ b/swift/Tests/MailCLITests/AccountAmbiguityTests.swift
@@ -140,6 +140,49 @@ final class AccountAmbiguityTests: XCTestCase {
             "Account name matches 2 accounts in Mail: Work (old). Rename one.")
     }
 
+    // MARK: - The stdout backstop
+
+    /// One JSON result carrying the marker, as a caught throw would produce it.
+    private func resultJSON(message: String) -> String {
+        "{\"results\":[],\"errors\":[{\"id\":\"<a@x>\",\"error\":\""
+            + AccountAmbiguity.jxaMarker + message
+            + "\"}],\"_lookup\":{\"backend\":\"jxa-only\"}}"
+    }
+
+    /// The caught path: a `catch` folded the marker into the script's JSON result and the
+    /// script exited 0. `assertAccountHintResolvable` stops scripts getting here; this makes
+    /// "the marker is not user-facing" hold even if one ever does again.
+    func testTheMarkerIsRecoveredFromAJSONResult() {
+        let json = resultJSON(message: "Account name matches 2 accounts in Mail: Shared. Rename one.")
+        XCTAssertEqual(AccountAmbiguity.messageFromJXAOutput(json),
+                       "Account name matches 2 accounts in Mail: Shared. Rename one.")
+    }
+
+    /// Stops at the JSON string's own closing quote rather than swallowing the rest of the
+    /// document.
+    func testTheRecoveredMessageStopsAtTheStringItLivesIn() {
+        let message = AccountAmbiguity.messageFromJXAOutput(
+            resultJSON(message: "Two accounts named Shared."))
+        XCTAssertEqual(message, "Two accounts named Shared.")
+        XCTAssertFalse(message?.contains("_lookup") ?? true, "must not run past its own string")
+    }
+
+    /// An account name carrying a quote or a backslash arrives JSON-escaped. It must come
+    /// back as itself rather than truncating the message at the escape.
+    func testJSONEscapesInTheAccountNameSurvive() {
+        // JSON source: ... matches 2 accounts in Mail: He said \"hi\" C:\\Mail. Rename one.
+        let json = resultJSON(
+            message: "Matches 2 accounts in Mail: He said \\\"hi\\\" C:\\\\Mail. Rename one.")
+        XCTAssertEqual(AccountAmbiguity.messageFromJXAOutput(json),
+                       "Matches 2 accounts in Mail: He said \"hi\" C:\\Mail. Rename one.")
+    }
+
+    func testOrdinaryOutputIsNotMistakenForARefusal() {
+        XCTAssertNil(AccountAmbiguity.messageFromJXAOutput(
+            "{\"results\":[{\"id\":\"<a@x>\"}],\"errors\":[]}"))
+        XCTAssertNil(AccountAmbiguity.messageFromJXAOutput(""))
+    }
+
     // MARK: - Both engines refuse, and say something true
 
     /// The two refusals are deliberately worded differently, and the JXA one must not repeat
@@ -223,7 +266,7 @@ final class AccountAmbiguityWiringTests: XCTestCase {
 final class GeneratedScriptSyntaxTests: XCTestCase {
 
     /// Compile `js` and return the compiler's complaint, or nil when it parsed.
-    private func compilationError(_ js: String) throws -> String? {
+    fileprivate func compilationError(_ js: String) throws -> String? {
         let osacompile = URL(fileURLWithPath: "/usr/bin/osacompile")
         guard FileManager.default.isExecutableFile(atPath: osacompile.path) else {
             throw XCTSkip("/usr/bin/osacompile unavailable")
@@ -286,5 +329,149 @@ final class GeneratedScriptSyntaxTests: XCTestCase {
             findHelper: generateUnifiedFindMsgJXA(
                 rowidMapJS: "{}", backend: "jxa-only", mailbox: nil, account: "Shared 'quoted'"))
         XCTAssertNil(try compilationError(script))
+    }
+}
+
+/// The batch commands, which swallowed the refusal.
+///
+/// `batch-update` and `batch-delete` wrap each entry's `findMsg()` in a JS `try/catch` that
+/// records the error and continues. That caught `resolveAccountsByHint`'s throw, so osascript
+/// exited 0, `runJXA`'s non-zero guard never fired, and the internal marker was rendered to
+/// the user once per message id — while `--engine sqlite` refused the same input non-zero.
+/// It also bit `--engine auto` without Full Disk Access, where `NoopLocator` resolves nothing
+/// and raises nothing, so no Swift-side check ran either.
+///
+/// These run the REAL emitted scripts against a fake Mail. The wiring assertions below would
+/// not have caught the original bug on their own — the helper WAS present and WAS called, one
+/// layer too deep — so the executable ones carry the weight here.
+final class BatchCommandAmbiguityTests: XCTestCase {
+
+    /// A fake `Mail` with `accounts` callable and carrying `.whose`, plus enough of a mailbox
+    /// surface for the finder's scan to complete when it is allowed to run.
+    private static func fakeMailDeclaration(accountNames: [String]) -> String {
+        let list = accountNames.map { "'\($0)'" }.joined(separator: ", ")
+        return """
+        function __acct(n) {
+            return {
+                name: function () { return n; },
+                mailboxes: Object.assign(function () { return []; },
+                                         {whose: function () { return function () { return []; }; }})
+            };
+        }
+        const __names = [\(list)];
+        const __accounts = Object.assign(
+            function () { return __names.map(__acct); },
+            {whose: function (p) {
+                return function () {
+                    return __names.filter(function (n) { return n === p.name; }).map(__acct);
+                };
+            }});
+        const Mail = {accounts: __accounts, delete: function () {}, move: function () {}};
+        """
+    }
+
+    private struct Run { let stdout: String; let stderr: String; let status: Int32 }
+
+    /// Swap `Application("Mail")` for the fake and execute. Nothing here touches Mail.app.
+    private func run(_ script: String, accountNames: [String]) throws -> Run {
+        let real = "const Mail = Application(\"Mail\");"
+        XCTAssertTrue(script.contains(real), "script must declare Mail the usual way")
+        let js = script.replacingOccurrences(
+            of: real, with: Self.fakeMailDeclaration(accountNames: accountNames))
+
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("script.js")
+        try js.write(to: file, atomically: true, encoding: .utf8)
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        proc.arguments = ["-l", "JavaScript", file.path]
+        let out = Pipe(), err = Pipe()
+        proc.standardOutput = out
+        proc.standardError = err
+        try proc.run()
+        let outData = out.fileHandleForReading.readDataToEndOfFile()
+        let errData = err.fileHandleForReading.readDataToEndOfFile()
+        proc.waitUntilExit()
+        return Run(stdout: String(decoding: outData, as: UTF8.self),
+                   stderr: String(decoding: errData, as: UTF8.self),
+                   status: proc.terminationStatus)
+    }
+
+    private func finder(account: String?) -> String {
+        generateUnifiedFindMsgJXA(rowidMapJS: "{}", backend: "jxa-only",
+                                  mailbox: nil, account: account)
+    }
+
+    private func batchScripts(account: String?) -> [(String, String)] {
+        [("batch-update",
+          BatchUpdateMessages.buildScript(jsUpdates: "{id: '<a@x>', read: true}, {id: '<b@x>', read: true}",
+                                          findHelper: finder(account: account))),
+         ("batch-delete",
+          BatchDeleteMessages.buildScript(jsIds: "'<a@x>', '<b@x>'",
+                                          findHelper: finder(account: account)))]
+    }
+
+    /// The bug: exit 0, and the marker rendered into the result once per id.
+    func testAnAmbiguousAccountRefusesTheWholeBatch() throws {
+        for (name, script) in batchScripts(account: "Shared") {
+            let result = try run(script, accountNames: ["Shared", "Shared"])
+
+            XCTAssertNotEqual(result.status, 0,
+                              "\(name): an ambiguous scope must fail the run, not each entry")
+            XCTAssertFalse(result.stdout.contains(AccountAmbiguity.jxaMarker),
+                           "\(name): the marker must never reach a result: \(result.stdout)")
+            XCTAssertTrue(result.stderr.contains(AccountAmbiguity.jxaMarker),
+                          "\(name): the refusal must reach the stderr runJXA reads")
+            // The refusal fires before any message is touched, so no per-entry error is
+            // recorded at all -- one refusal for the batch, not N.
+            XCTAssertFalse(result.stdout.contains("<a@x>"),
+                           "\(name): nothing may be reported per entry: \(result.stdout)")
+        }
+    }
+
+    /// Whatever the fix does, it must not refuse a batch that is fine. Two distinct accounts
+    /// with a hint naming one, and no hint at all, both still run.
+    func testUnambiguousBatchesStillRun() throws {
+        for (name, script) in batchScripts(account: "Work") {
+            let result = try run(script, accountNames: ["Work", "Home"])
+            XCTAssertEqual(result.status, 0, "\(name) with a unique hint: \(result.stderr)")
+            XCTAssertTrue(result.stdout.contains("results"), "\(name): \(result.stdout)")
+        }
+        for (name, script) in batchScripts(account: nil) {
+            let result = try run(script, accountNames: ["Work", "Home"])
+            XCTAssertEqual(result.status, 0, "\(name) with no hint: \(result.stderr)")
+        }
+    }
+
+    /// Wiring: the assert is emitted, and emitted *before* the `try` that would eat it.
+    /// Position is the whole point, so it is asserted rather than mere presence.
+    func testTheAssertIsEmittedAheadOfThePerEntryTryCatch() {
+        for (name, script) in batchScripts(account: "Shared") {
+            guard let assertion = script.range(of: "assertAccountHintResolvable(Mail, acctHint);"),
+                  let firstTry = script.range(of: "try {") else {
+                return XCTFail("\(name): expected both the assert and a per-entry try")
+            }
+            XCTAssertLessThan(assertion.lowerBound, firstTry.lowerBound,
+                              "\(name): the assert must run before anything can catch it")
+        }
+    }
+
+    /// The generated batch scripts still parse with the assert in them.
+    func testTheBatchScriptsStillCompile() throws {
+        let syntax = GeneratedScriptSyntaxTests()
+        for (name, script) in batchScripts(account: "Shared 'quoted'") {
+            XCTAssertNil(try syntax.compilationErrorForTesting(script), name)
+        }
+    }
+}
+
+extension GeneratedScriptSyntaxTests {
+    /// Exposed so `BatchCommandAmbiguityTests` can reuse the compiler check.
+    func compilationErrorForTesting(_ js: String) throws -> String? {
+        try compilationError(js)
     }
 }


### PR DESCRIPTION
Follow-up to #143. The review finding is **correct** — confirmed by reading and then by execution.

## The hole

#143's refusal is a thrown JS Error, and a throw is only a refusal if nobody catches it. `BatchUpdateMessages.buildScript` and `BatchDeleteMessages.buildScript` wrap each entry's `findMsg()` in a per-entry `try/catch`:

```js
try { const _r = findMsg(u.id); … } catch(e) { errors.push({id: u.id, error: e.message || String(e)}); }
```

Reproduced by executing the real emitted scripts against a fake `Mail` with two accounts named `Shared`:

```
--- batch-delete ---   exit: 0     ← runJXA's non-zero guard never fires
{"results":[],"errors":[
  {"id":"<a@x>","error":"APPLE_PIM_ACCOUNT_AMBIGUOUS:Account name matches 2 accounts in Mail: Shared…"},
  {"id":"<b@x>","error":"APPLE_PIM_ACCOUNT_AMBIGUOUS:Account name matches 2 accounts in Mail: Shared…"}]}
```

Both halves of the finding hold: the engines did **not** refuse identically (sqlite exits non-zero, JXA exited 0), and the internal marker reached the user verbatim, once per id — directly contradicting `AccountAmbiguity.swift`'s "Not user-facing". And as the review notes, this is not an edge case for the audience: `--engine auto` without Full Disk Access lands here too, because `NoopLocator.resolve` returns an empty map without raising.

I re-ran the try/catch audit with `\(findHelper)` actually inlined. It finds **exactly two** swallowing sites, the two named — no more:

```
  line  finder call in try?  what
  1764  *** SWALLOWED ***    const _r = findMsg(u.id);
  1877  *** SWALLOWED ***    const _r = findMsg(targetId);
  (16 other invocations: clean)
```

## The fix

Took the **hoist**, as suggested — it is the better semantics as well as the fix.

1. **`assertAccountHintResolvable(Mail, acctHint)` at script top level**, emitted by the write finder ahead of every loop and every `try`. The refusal fires before any message is touched: one refusal for the batch rather than N per-entry errors. Guarded on the hint, so the no-`--account` case does no work at all and stays as lazy as it was — no eager account enumeration on a path that may never need it.
2. **`runJXA` also reads the marker out of stdout** and throws `CLIError.invalidInput`. This is the backstop: it makes "the marker is not user-facing" a property of one function rather than a claim about every `catch` block in every generated script — which is exactly the claim that turned out to be false.
3. **The false comment is corrected.** "It cannot be dropped by a call site that forgot to look" was the belief that allowed this, so it now says what actually holds and names the batch commands as the counterexample.

After:

```
--- batch-delete ---   exit: 1   marker in stdout: False   marker in stderr: True   stdout: (empty)
--- batch-update ---   exit: 1   marker in stdout: False   marker in stderr: True   stdout: (empty)
```

## Tests

Executable, not grep — the existing wiring assertions would **not** have caught this, since the helper *was* present and *was* called, one layer too deep. So `BatchCommandAmbiguityTests` runs the real emitted batch scripts against a fake `Mail`:

- ambiguous hint → non-zero exit, no marker in stdout, marker on stderr, and **no per-entry error at all** (pinning "refuses the batch", not "refuses each entry")
- unambiguous hint, and no hint → both still run, exit 0
- the assert is emitted *before* the first `try` (position is the point, so it is asserted, not just presence)
- the batch scripts still compile

Plus unit tests for the stdout reader, including JSON unescaping so an account name containing `"` or `\` survives rather than truncating the message.

**Negative control:** removing the top-level assert fails these **9 ways** across 2 tests.

`swift test`: **185 tests, 0 failures** (was 177).

## LOW — docs narrowed

`MessageLocator.swift` and `skills/apple-pim/references/mail-jxa.md` now scope the claim to hints the **caller** supplies, and document `buildReplyAppleScript`'s `first account whose name is …` as the remaining derived-name site alongside `getAccountByName` — including that its failure mode is the misleading "Could not locate the original message" rather than an ambiguity error. Left unfixed deliberately: closing it means teaching the AppleScript reply path to address accounts by something other than name, which is a different change.

## How it got through

My try/catch audit on #143 stubbed `\(findHelper)` out to `null`, so the batch scripts contained no `resolveAccountsByHint` in the checked text and were **skipped silently**. It reported six clean scripts and never said which ones it had not looked at — the same "green because nothing ran it" shape as the CI hole in #122.

Nothing here releases, tags, or publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDD6P9ft7DNNbrXpNWvCsk