### PR TITLE
fix(helper): route mail-cli through PIMHelper for TCC

### DIFF
--- a/helper/Info.plist
+++ b/helper/Info.plist
@@ -20,6 +20,8 @@
     <true/>
     <key>LSBackgroundOnly</key>
     <false/>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>Apple PIM Helper controls Mail.app to read and manage messages on behalf of the Apple PIM plugin.</string>
     <key>NSCalendarsFullAccessUsageDescription</key>
     <string>Apple PIM Helper needs full Calendar access to read and manage events on behalf of the Apple PIM plugin.</string>
     <key>NSCalendarsUsageDescription</key>

--- a/helper/pim-helper
+++ b/helper/pim-helper
@@ -8,7 +8,7 @@
 # shell (e.g. an embedded agent runtime) having its own TCC entry.
 #
 # Args: <cli-name> <out-file> <err-file> [cli-args...]
-#   cli-name : one of calendar-cli, reminder-cli, contacts-cli
+#   cli-name : one of calendar-cli, reminder-cli, contacts-cli, mail-cli
 #   out-file : absolute path to write the CLI's stdout to
 #   err-file : absolute path to write the CLI's stderr to
 #   cli-args : forwarded verbatim to the CLI
@@ -26,7 +26,7 @@ ERR="$3"
 shift 3
 
 case "$CLI" in
-    calendar-cli|reminder-cli|contacts-cli) ;;
+    calendar-cli|reminder-cli|contacts-cli|mail-cli) ;;
     *)
         echo "pim-helper: unsupported cli '$CLI'" >"$ERR"
         : >"$OUT"

--- a/lib/cli-runner.js
+++ b/lib/cli-runner.js
@@ -431,6 +431,33 @@ async function launchHelper(cli, args, env, timeoutMs, binDir) {
  * @param {{ timeoutMs?: number }} options - Options (e.g. timeout).
  * @returns {{ runCLI: (cli: string, args: string[]) => Promise<object> }}
  */
+/**
+ * Route decision for mail-cli's `auth-status` payload.
+ *
+ * Split out from probeRoute() so the state table can be tested directly; the
+ * states come from swift/Sources/MailCLI/MailCLI.swift.
+ *
+ * mail-cli straddles two independent TCC boundaries and reports them in two
+ * different fields: `authorization` covers Mail.app Automation only (writes),
+ * while Full Disk Access appears as envelopeIndex.readable (reads). Only a
+ * host holding BOTH can safely skip the helper.
+ *
+ * "unavailable" is the trap. mail-cli returns it whenever Mail.app is not
+ * running, decided before any TCC check happens, so it says nothing about
+ * permissions. Reading it as a green light would cache the direct route on a
+ * host with no Mail grants at all, and the first real send would launch
+ * Mail.app into an Automation denial attributed to the caller — the exact
+ * failure the helper exists to prevent.
+ */
+export function mailRouteFromAuthStatus(status) {
+  const auth = status?.authorization;
+  const readable = status?.envelopeIndex?.readable === true;
+  if (auth === "authorized" && readable) {
+    return { route: "direct", mayPrompt: false };
+  }
+  return { route: "helper", mayPrompt: auth === "notDetermined" };
+}
+
 export function createCLIRunner(binDir, envOverrides = {}, { timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
   // Per-CLI routing decision. Stores a Promise<{route, mayPrompt}> rather
   // than the resolved value so concurrent first calls for the same CLI
@@ -491,6 +518,12 @@ export function createCLIRunner(binDir, envOverrides = {}, { timeoutMs = DEFAULT
     try {
       const result = await runDirect(cliPath, ["auth-status"], childEnv(), timeoutMs);
       const auth = result?.authorization;
+
+      // See mailRouteFromAuthStatus() for why mail needs its own rule.
+      if (cli === "mail-cli") {
+        return mailRouteFromAuthStatus(result);
+      }
+
       if (auth === "notDetermined") {
         // First helper call will raise the macOS permission dialog.
         return { route: "helper", mayPrompt: true };

--- a/lib/cli-runner.js
+++ b/lib/cli-runner.js
@@ -136,11 +136,24 @@ const PROMPT_TIMEOUT_MS = 120_000;
  */
 const STALE_HELPER_SECONDS = Math.ceil(PROMPT_TIMEOUT_MS / 1000) + 10;
 
-/** CLIs that go through Calendar / Reminders / Contacts TCC services. */
+/**
+ * CLIs whose access is gated by a per-responsible-process TCC service.
+ *
+ * calendar/reminder/contacts go through EventKit and Contacts, which attribute
+ * to the responsible process. mail-cli is here for the same reason by a
+ * different route: its reads open Mail's Envelope Index under ~/Library/Mail,
+ * which is Full Disk Access, and its writes drive Mail.app over JXA, which is
+ * Automation. A host without those grants (the gateway's node, say) gets
+ * notDetermined and needs the helper's stable bundle identity.
+ *
+ * Membership alone does not force the helper: probeRoute() still tries direct
+ * first and only falls back when TCC actually refuses this process tree.
+ */
 const HELPER_ELIGIBLE_CLIS = new Set([
   "calendar-cli",
   "reminder-cli",
   "contacts-cli",
+  "mail-cli",
 ]);
 
 /** Resolve the helper .app path (overridable for testing / non-default installs). */

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -68779,7 +68779,7 @@ var Doc = class {
 var version = {
   major: 4,
   minor: 3,
-  patch: 5
+  patch: 6
 };
 
 // node_modules/zod/v4/core/schemas.js
@@ -70070,7 +70070,7 @@ var $ZodRecord = /* @__PURE__ */ $constructor("$ZodRecord", (inst, def) => {
         if (keyResult instanceof Promise) {
           throw new Error("Async schemas not supported in object keys currently");
         }
-        const checkNumericKey = typeof key === "string" && number.test(key) && keyResult.issues.length && keyResult.issues.some((iss) => iss.code === "invalid_type" && iss.expected === "number");
+        const checkNumericKey = typeof key === "string" && number.test(key) && keyResult.issues.length;
         if (checkNumericKey) {
           const retryResult = def.keyType._zod.run({ value: Number(key), issues: [] }, ctx);
           if (retryResult instanceof Promise) {
@@ -71915,7 +71915,7 @@ function finalize(ctx, schema) {
           }
         }
       }
-      if (refSchema.$ref) {
+      if (refSchema.$ref && refSeen.def) {
         for (const key in schema2) {
           if (key === "$ref" || key === "allOf")
             continue;
@@ -75714,6 +75714,9 @@ var Protocol = class {
    * The Protocol object assumes ownership of the Transport, replacing any callbacks that have already been set, and expects that it is the only user of the Transport instance going forward.
    */
   async connect(transport) {
+    if (this._transport) {
+      throw new Error("Already connected to a transport. Call close() before connecting to a new transport, or use a separate Protocol instance per connection.");
+    }
     this._transport = transport;
     const _onclose = this.transport?.onclose;
     this._transport.onclose = () => {
@@ -75746,6 +75749,10 @@ var Protocol = class {
     this._progressHandlers.clear();
     this._taskProgressTokens.clear();
     this._pendingDebouncedNotifications.clear();
+    for (const controller of this._requestHandlerAbortControllers.values()) {
+      controller.abort();
+    }
+    this._requestHandlerAbortControllers.clear();
     const error2 = McpError.fromError(ErrorCode.ConnectionClosed, "Connection closed");
     this._transport = void 0;
     this.onclose?.();
@@ -75796,6 +75803,8 @@ var Protocol = class {
       sessionId: capturedTransport?.sessionId,
       _meta: request.params?._meta,
       sendNotification: async (notification) => {
+        if (abortController.signal.aborted)
+          return;
         const notificationOptions = { relatedRequestId: request.id };
         if (relatedTaskId) {
           notificationOptions.relatedTask = { taskId: relatedTaskId };
@@ -75803,6 +75812,9 @@ var Protocol = class {
         await this.notification(notification, notificationOptions);
       },
       sendRequest: async (r, resultSchema, options) => {
+        if (abortController.signal.aborted) {
+          throw new McpError(ErrorCode.ConnectionClosed, "Request was cancelled");
+        }
         const requestOptions = { ...options, relatedRequestId: request.id };
         if (relatedTaskId && !requestOptions.relatedTask) {
           requestOptions.relatedTask = { taskId: relatedTaskId };
@@ -77396,7 +77408,8 @@ var STALE_HELPER_SECONDS = Math.ceil(PROMPT_TIMEOUT_MS / 1e3) + 10;
 var HELPER_ELIGIBLE_CLIS = /* @__PURE__ */ new Set([
   "calendar-cli",
   "reminder-cli",
-  "contacts-cli"
+  "contacts-cli",
+  "mail-cli"
 ]);
 function helperAppPath() {
   return process.env.APPLE_PIM_HELPER_APP || join(homedir(), "Applications", "PIMHelper.app");
@@ -77554,6 +77567,14 @@ async function launchHelper(cli, args, env, timeoutMs, binDir) {
     });
   });
 }
+function mailRouteFromAuthStatus(status) {
+  const auth = status?.authorization;
+  const readable = status?.envelopeIndex?.readable === true;
+  if (auth === "authorized" && readable) {
+    return { route: "direct", mayPrompt: false };
+  }
+  return { route: "helper", mayPrompt: auth === "notDetermined" };
+}
 function createCLIRunner(binDir, envOverrides = {}, { timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
   const route = /* @__PURE__ */ new Map();
   function childEnv() {
@@ -77606,6 +77627,9 @@ ${describeBinDirProblem(probeSwiftBinDirs([binDir]))}`;
     try {
       const result = await runDirect(cliPath, ["auth-status"], childEnv(), timeoutMs);
       const auth = result?.authorization;
+      if (cli === "mail-cli") {
+        return mailRouteFromAuthStatus(result);
+      }
       if (auth === "notDetermined") {
         return { route: "helper", mayPrompt: true };
       }

--- a/mcp-server/test/mail-route.test.js
+++ b/mcp-server/test/mail-route.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { mailRouteFromAuthStatus } from "../../lib/cli-runner.js";
+
+// The state table is mail-cli's, not ours: swift/Sources/MailCLI/MailCLI.swift
+// emits authorized / notDetermined / denied / unavailable / error for Mail.app
+// Automation, and reports Full Disk Access separately as envelopeIndex.readable.
+// Mail needs both, so only the both-granted case may skip the helper.
+describe("mailRouteFromAuthStatus", () => {
+  it("goes direct only when Automation and Full Disk Access are both granted", () => {
+    expect(
+      mailRouteFromAuthStatus({ authorization: "authorized", envelopeIndex: { readable: true } }),
+    ).toEqual({ route: "direct", mayPrompt: false });
+  });
+
+  it("uses the helper when Automation is granted but the Envelope Index is unreadable", () => {
+    // Reads open ~/Library/Mail directly, so Automation alone is not enough.
+    expect(
+      mailRouteFromAuthStatus({ authorization: "authorized", envelopeIndex: { readable: false } }),
+    ).toEqual({ route: "helper", mayPrompt: false });
+  });
+
+  it("uses the helper when Mail.app is not running", () => {
+    // "unavailable" is returned before any TCC check, so it carries no
+    // permission signal. Treating it as a green light would cache the direct
+    // route on a host with no Mail grants at all.
+    expect(
+      mailRouteFromAuthStatus({
+        authorization: "unavailable",
+        message: "Mail.app is not running",
+        envelopeIndex: { readable: true },
+      }),
+    ).toEqual({ route: "helper", mayPrompt: false });
+  });
+
+  it("flags a prompt only for notDetermined", () => {
+    expect(
+      mailRouteFromAuthStatus({ authorization: "notDetermined", envelopeIndex: { readable: true } }),
+    ).toEqual({ route: "helper", mayPrompt: true });
+  });
+
+  it("uses the helper without prompting when Automation is denied", () => {
+    expect(
+      mailRouteFromAuthStatus({ authorization: "denied", envelopeIndex: { readable: true } }),
+    ).toEqual({ route: "helper", mayPrompt: false });
+  });
+
+  it("uses the helper for unknown shapes rather than failing open", () => {
+    for (const status of [undefined, {}, { authorization: "error" }]) {
+      expect(mailRouteFromAuthStatus(status).route).toBe("helper");
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`mail-cli` was excluded from helper routing in **both** layers — the dispatcher's `case` allowlist in `helper/pim-helper` and `HELPER_ELIGIBLE_CLIS` in `lib/cli-runner.js`. That left it with no path to authorization from any host that lacks its own TCC grants.

Concretely: the OpenClaw gateway runs as a launchd LaunchAgent whose node binary holds neither Full Disk Access nor Automation. `apple_pim_system` reported `mail=notDetermined` indefinitely, with no mechanism to ever raise a prompt.

## Why mail belongs in the helper set

It isn't an EventKit domain, but it needs the same stable bundle identity for two separate reasons:

- **Reads** open Mail's Envelope Index under `~/Library/Mail` — Full Disk Access
- **Writes** drive Mail.app over JXA — Automation

`NSAppleEventsUsageDescription` is added because macOS refuses to render an Automation prompt at all when the usage description is absent, and fails silently rather than reporting why.

## Not a behavior change for working hosts

Membership in `HELPER_ELIGIBLE_CLIS` does not force helper routing. `probeRoute()` still probes direct first and falls back only when TCC actually refuses the current process tree, so hosts that already hold the grants keep going direct.

## Verification

- `vitest run` in `mcp-server`: **90 passed**, including `cli-runner-helper-proc`
- Diagnosed against a live gateway: Calendar, Reminders and Contacts all reached `authorized` through the helper; mail remains `notDetermined` pending a helper rebuild plus a Full Disk Access grant.

## Follow-up required

The installed helper must be rebuilt (`scripts/build-helper-app.sh --force`) and granted Full Disk Access for the gateway path to work end to end. Note that rebuilding re-signs the bundle and **drops existing Calendar/Reminders/Contacts grants**, so it should be done in one sitting with someone at the machine to re-answer the prompts. Unlike Reminders and Contacts, the Full Disk Access pane accepts a manual entry.

## Incidental finding

`reminder-cli` was separately reporting `Unable to block on applications (initial call to kevent() failed: No such process)`. That is not a permissions failure and needs no code change: the helper app is single-instance, so an unanswered Contacts prompt wedges it for the full 120s timeout and `open -W` collides (Launch Services `-1712`) for every other domain. Reminders returned to `authorized` on its own once Contacts was granted. Worth knowing that one unanswered prompt starves all four domains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFhd1rcXuwUchP7o5bxcdM