### PR TITLE
fix: point Homebrew at the signed assets, and catch bundle version drift

### DIFF
--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -1,26 +1,38 @@
 name: Publish to Homebrew Tap
 
+# Triggered by publishing a release, NOT by pushing a tag.
+#
+# The formula now points at the signed release asset rather than the source
+# tarball. That asset is produced by release-signed-artifacts.yml, which runs
+# in parallel on the same tag and takes several minutes (notarization), and it
+# lands in a DRAFT release whose assets are not anonymously downloadable. A
+# tag-triggered run would therefore race the signing job and, even after it,
+# point the formula at a URL nobody can fetch.
+#
+# Keying on `release: published` removes the race entirely: the assets exist
+# and are public by definition.
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 permissions:
   contents: read
 
-# Bumps the apple-pim-cli formula in omarshahine/homebrew-tap to the tag that
-# triggered this run. The formula builds from the GitHub source tarball, so we
-# only need to update `url` and `sha256` — no bottle upload.
+# Bumps the apple-pim-cli formula in omarshahine/homebrew-tap to the published
+# release. The formula installs the Developer ID signed, notarized, universal
+# binaries from the release asset -- building from source produced ad-hoc
+# signed binaries, which macOS pins TCC grants to by content hash, so every
+# `brew upgrade` silently revoked the user's Calendar/Reminders/Contacts
+# access.
 #
 # Requires a repo secret HOMEBREW_TAP_TOKEN: a fine-grained PAT scoped to
 # omarshahine/homebrew-tap with Contents: read & write. The default GITHUB_TOKEN
 # cannot push to a different repository.
 jobs:
-  # Publishing is gated on the SDK actually shipping what the mail channel calls,
-  # because the three publish workflows fire independently on the same tag. Without
-  # this, a premature tag fails the two npm-installing workflows and SUCCEEDS on
-  # Homebrew, which builds the Swift CLI from the source tarball and never touches
-  # openclaw/. That leaves the tap pointing at a version npm and ClawHub never got,
+  # Publishing is gated on the SDK actually shipping what the mail channel calls.
+  # The npm and ClawHub workflows fire on the tag and would fail on a premature
+  # one; this job never touches openclaw/, so without the gate it could still
+  # succeed and leave the tap pointing at a version those registries never got,
   # which is worse than nothing publishing at all.
   preflight:
     name: SDK contract preflight
@@ -68,24 +80,32 @@ jobs:
       TAP_REPO: omarshahine/homebrew-tap
       FORMULA_PATH: Formula/apple-pim-cli.rb
     steps:
-      - name: Resolve version and tarball checksum
+      - name: Resolve the signed asset and its checksum
         id: meta
+        env:
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          TARBALL="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${GITHUB_REF_NAME}.tar.gz"
-          echo "Fetching $TARBALL"
-          # Retry to absorb the brief delay before GitHub serves a fresh tag tarball.
+          VERSION="${TAG#v}"
+          ASSET="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/apple-pim-clis-${VERSION}-universal.zip"
+          echo "Fetching $ASSET"
           for attempt in 1 2 3 4 5; do
-            if curl -fsSL "$TARBALL" -o source.tar.gz; then
+            if curl -fsSL "$ASSET" -o signed.zip; then
               break
             fi
             echo "Attempt $attempt failed; retrying in 10s..."
             sleep 10
           done
-          SHA256=$(sha256sum source.tar.gz | awk '{print $1}')
-          echo "version=$VERSION"   >> "$GITHUB_OUTPUT"
-          echo "tarball=$TARBALL"   >> "$GITHUB_OUTPUT"
-          echo "sha256=$SHA256"     >> "$GITHUB_OUTPUT"
+          # Fail loudly rather than shipping a formula pointing at nothing. A
+          # release published without the signed asset (an older tag, or a
+          # signing run that failed) must not silently update the tap.
+          if [ ! -s signed.zip ]; then
+            echo "::error::no signed asset at $ASSET — refusing to update the formula"
+            exit 1
+          fi
+          SHA256=$(sha256sum signed.zip | awk '{print $1}')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "asset=$ASSET"     >> "$GITHUB_OUTPUT"
+          echo "sha256=$SHA256"   >> "$GITHUB_OUTPUT"
           echo "Resolved v$VERSION -> $SHA256"
 
       - name: Checkout tap
@@ -99,15 +119,16 @@ jobs:
         run: |
           cd tap
           FILE="${FORMULA_PATH}"
-          NEW_URL="${{ steps.meta.outputs.tarball }}"
+          NEW_URL="${{ steps.meta.outputs.asset }}"
           NEW_SHA="${{ steps.meta.outputs.sha256 }}"
 
-          # Replace the archive url and the sha256 that immediately follows it.
-          # The url match is deliberately NOT anchored on GITHUB_REPOSITORY:
-          # after the 2026 repo rename the old anchor no-op'd against the
-          # formula's stale url while the sha256 replace ran anyway, shipping
-          # a url/sha mismatch that broke `brew install` (tap commit 88537d0).
-          perl -0pi -e "s{url \"https://github\.com/[^\"]+/archive/refs/tags/v[^\"]+\.tar\.gz\"}{url \"$NEW_URL\"}" "$FILE"
+          # Replace the asset url and the sha256 that immediately follows it.
+          # Deliberately NOT anchored on GITHUB_REPOSITORY: after the 2026 repo
+          # rename the old anchor no-op'd against the formula's stale url while
+          # the sha256 replace ran anyway, shipping a url/sha mismatch that
+          # broke `brew install` (tap commit 88537d0). Anchored at two-space
+          # indent so it only ever matches the formula-level url.
+          perl -0pi -e "s{^  url \"[^\"]+\"}{  url \"$NEW_URL\"}m" "$FILE"
           perl -0pi -e "s{^(\s*)sha256 \"[0-9a-f]{64}\"}{\${1}sha256 \"$NEW_SHA\"}m" "$FILE"
 
           # Fail loudly if either replacement missed — a partial update is

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -88,8 +88,12 @@ jobs:
           VERSION="${TAG#v}"
           ASSET="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/apple-pim-clis-${VERSION}-universal.zip"
           echo "Fetching $ASSET"
+          # --remove-on-error: without it an aborted transfer leaves the
+          # partial bytes on disk, and a non-empty check would accept that
+          # truncated archive, publish its checksum, and make `brew install`
+          # reject the real asset for a checksum mismatch.
           for attempt in 1 2 3 4 5; do
-            if curl -fsSL "$ASSET" -o signed.zip; then
+            if curl -fsSL --remove-on-error "$ASSET" -o signed.zip; then
               break
             fi
             echo "Attempt $attempt failed; retrying in 10s..."
@@ -102,7 +106,24 @@ jobs:
             echo "::error::no signed asset at $ASSET — refusing to update the formula"
             exit 1
           fi
+
+          # Verify against the checksums the signing job published alongside
+          # the asset, so a silently corrupted or truncated download cannot
+          # become the formula's sha256. Size alone proves nothing.
+          SUMS="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/SHA256SUMS"
+          if ! curl -fsSL --remove-on-error "$SUMS" -o SHA256SUMS; then
+            echo "::error::release $TAG has no SHA256SUMS — refusing to update the formula"
+            exit 1
+          fi
+          EXPECTED=$(awk -v f="./apple-pim-clis-${VERSION}-universal.zip" \
+            '$2 == f || $2 == substr(f,3) {print $1}' SHA256SUMS | head -1)
           SHA256=$(sha256sum signed.zip | awk '{print $1}')
+          if [ -z "$EXPECTED" ] || [ "$EXPECTED" != "$SHA256" ]; then
+            echo "::error::downloaded asset does not match the published SHA256SUMS"
+            echo "::error::expected=${EXPECTED:-<absent>} actual=$SHA256"
+            exit 1
+          fi
+          echo "Checksum matches the published SHA256SUMS."
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "asset=$ASSET"     >> "$GITHUB_OUTPUT"
           echo "sha256=$SHA256"   >> "$GITHUB_OUTPUT"
@@ -121,6 +142,23 @@ jobs:
           FILE="${FORMULA_PATH}"
           NEW_URL="${{ steps.meta.outputs.asset }}"
           NEW_SHA="${{ steps.meta.outputs.sha256 }}"
+          NEW_VER="${{ steps.meta.outputs.version }}"
+
+          # Refuse to move the tap backwards. Draft releases accumulate, and
+          # publishing an old one later is an ordinary mistake -- this event
+          # says "a release was published", not "the newest release". Without
+          # this, doing so downgrades every `brew upgrade` user.
+          CUR_VER=$(sed -n 's|^  url ".*apple-pim-clis-\([0-9][0-9.]*\)-universal.*|\1|p' "$FILE" | head -1)
+          if [ -n "$CUR_VER" ]; then
+            NEWEST=$(printf '%s\n%s\n' "$CUR_VER" "$NEW_VER" | sort -V | tail -1)
+            if [ "$NEWEST" != "$NEW_VER" ]; then
+              echo "::error::refusing to downgrade the tap: formula is at $CUR_VER, this release is $NEW_VER"
+              exit 1
+            fi
+            echo "Formula at $CUR_VER -> $NEW_VER"
+          else
+            echo "Formula has no signed-asset url yet; treating as first switch."
+          fi
 
           # Replace the asset url and the sha256 that immediately follows it.
           # Deliberately NOT anchored on GITHUB_REPOSITORY: after the 2026 repo

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -228,3 +228,12 @@ jobs:
                 - mcp-server/package.json:.version
                 - openclaw/package.json:.version
                 - openclaw/openclaw.plugin.json:.version
+
+      # The action above compares JSON paths, so it structurally cannot see the
+      # version baked into the committed mcp-server/dist/server.js bundle --
+      # which is the artifact that actually ships. bump-version.sh writes the
+      # JSON files first and rebuilds the bundle last, so a failed rebuild
+      # leaves them disagreeing while every JSON path still reads as correct.
+      # scripts/check-versions.sh compares the bundle too.
+      - name: Built bundle agrees with the manifests
+        run: bash scripts/check-versions.sh

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -66,6 +66,38 @@ set_json_field() {
   mv "$tmp" "$file"
 }
 
+# Roll the version files back if anything downstream fails.
+#
+# The preflight above catches the common causes, but enumerating build
+# dependencies can never be complete -- the bundle's own import graph can grow
+# a new one at any time, and then the manifests are rewritten and the rebuild
+# fails anyway. This makes the operation all-or-nothing regardless of why the
+# rebuild failed, so a failure can never leave the manifests at the new version
+# with the shipped bundle at the old one.
+BUMP_FILES=(
+  .claude-plugin/plugin.json
+  .claude-plugin/marketplace.json
+  mcp-server/package.json
+  openclaw/package.json
+  openclaw/openclaw.plugin.json
+)
+BUMP_BACKUP="$(mktemp -d)"
+for f in "${BUMP_FILES[@]}"; do
+  mkdir -p "$BUMP_BACKUP/$(dirname "$f")"
+  cp "$f" "$BUMP_BACKUP/$f"
+done
+bump_rollback() {
+  local status=$?
+  if [ "$status" -ne 0 ]; then
+    for f in "${BUMP_FILES[@]}"; do cp "$BUMP_BACKUP/$f" "$f"; done
+    echo >&2
+    echo "error: bump failed; version files rolled back (nothing was changed)." >&2
+  fi
+  rm -rf "$BUMP_BACKUP"
+  return $status
+}
+trap bump_rollback EXIT
+
 set_json_field .claude-plugin/plugin.json       ".version = \"$new\""
 set_json_field .claude-plugin/marketplace.json  ".plugins[0].version = \"$new\""
 set_json_field mcp-server/package.json          ".version = \"$new\""

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -36,6 +36,29 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 2
 fi
 
+# Check the bundle can actually be rebuilt BEFORE writing any version file.
+#
+# The five JSON files are written first and mcp-server/dist/server.js is
+# rebuilt last. Without this, a missing build dependency leaves a half-applied
+# bump: every JSON file reads as the new version while the artifact that
+# actually ships still carries the old one. The script does exit non-zero in
+# that case, but the damage is already on disk, and it is easy to miss when the
+# output is piped. scripts/check-versions.sh now also compares the built bundle
+# so the drift cannot ship silently, but failing here first is cheaper.
+missing=""
+[ -x mcp-server/node_modules/.bin/esbuild ] || missing="$missing mcp-server/node_modules (esbuild)"
+# lib/ pulls these from the repo root; esbuild cannot resolve them otherwise.
+for dep in mailparser turndown; do
+  [ -d "node_modules/$dep" ] || missing="$missing node_modules/$dep"
+done
+if [ -n "$missing" ]; then
+  echo "error: cannot rebuild mcp-server/dist/server.js; missing:$missing" >&2
+  echo "  run: npm install && npm install --prefix mcp-server" >&2
+  echo "  (refusing to bump: a failed rebuild would leave the version files" >&2
+  echo "   updated and the shipped bundle stale)" >&2
+  exit 2
+fi
+
 set_json_field() {
   local file="$1" jq_expr="$2" tmp
   tmp=$(mktemp)

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Verify that all five plugin version sources agree.
+# Verify that all plugin version sources agree.
 # Exits non-zero if any disagree; prints a table either way.
 #
 # Sources:
@@ -9,6 +9,14 @@
 #   - mcp-server/package.json                    .version
 #   - openclaw/package.json                      .version
 #   - openclaw/openclaw.plugin.json              .version
+#   - mcp-server/dist/server.js                  embedded `version: "X.Y.Z"`
+#
+# The bundle is included because it is the artifact that actually ships, and it
+# is generated: scripts/bump-version.sh writes the five JSON files first and
+# rebuilds the bundle afterwards, so a failed rebuild leaves the bundle at the
+# previous version while every JSON file reads as correct. The CI "Version
+# Consistency" action compares JSON paths and cannot see inside a JS bundle, so
+# without this check that drift is invisible and ships.
 
 set -euo pipefail
 
@@ -25,6 +33,19 @@ read -r v_mcp           < <(jq -r '.version'             mcp-server/package.json
 read -r v_openclaw_pkg  < <(jq -r '.version'             openclaw/package.json)
 read -r v_openclaw_man  < <(jq -r '.version'             openclaw/openclaw.plugin.json)
 
+# Generated artifact: absent in a fresh checkout that has not built yet, which
+# is not a version mismatch. Only compared when it exists.
+#
+# Anchored on the package identity, not position: the bundle inlines its
+# dependencies' package.json objects too, and one of those (encoding-japanese)
+# appears first. Matching the first `version:` literal would compare the wrong
+# package and fail for the wrong reason.
+v_bundle=""
+if [ -f mcp-server/dist/server.js ]; then
+  v_bundle=$(grep -A1 '"apple-pim-mcp"' mcp-server/dist/server.js \
+    | sed -n 's/.*version:[[:space:]]*"\([0-9][^"]*\)".*/\1/p' | head -1)
+fi
+
 printf "%-40s %s\n" "File" "Version"
 printf "%-40s %s\n" "----" "-------"
 printf "%-40s %s\n" ".claude-plugin/plugin.json"        "$v_plugin"
@@ -32,8 +53,14 @@ printf "%-40s %s\n" ".claude-plugin/marketplace.json"   "$v_marketplace"
 printf "%-40s %s\n" "mcp-server/package.json"           "$v_mcp"
 printf "%-40s %s\n" "openclaw/package.json"             "$v_openclaw_pkg"
 printf "%-40s %s\n" "openclaw/openclaw.plugin.json"     "$v_openclaw_man"
+if [ -n "$v_bundle" ]; then
+  printf "%-40s %s\n" "mcp-server/dist/server.js (built)" "$v_bundle"
+else
+  printf "%-40s %s\n" "mcp-server/dist/server.js (built)" "(not built)"
+fi
 
 all="$v_plugin $v_marketplace $v_mcp $v_openclaw_pkg $v_openclaw_man"
+[ -n "$v_bundle" ] && all="$all $v_bundle"
 uniq=$(printf '%s\n' $all | sort -u | wc -l | tr -d ' ')
 
 if [ "$uniq" != "1" ]; then

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -33,17 +33,25 @@ read -r v_mcp           < <(jq -r '.version'             mcp-server/package.json
 read -r v_openclaw_pkg  < <(jq -r '.version'             openclaw/package.json)
 read -r v_openclaw_man  < <(jq -r '.version'             openclaw/openclaw.plugin.json)
 
-# Generated artifact: absent in a fresh checkout that has not built yet, which
-# is not a version mismatch. Only compared when it exists.
+# The bundle is a TRACKED shipping artifact, so its absence is a problem in its
+# own right, not a "not built yet" state: a checkout always has it, and deleting
+# it would otherwise sail through this check whenever the JSON files agree.
 #
 # Anchored on the package identity, not position: the bundle inlines its
 # dependencies' package.json objects too, and one of those (encoding-japanese)
 # appears first. Matching the first `version:` literal would compare the wrong
 # package and fail for the wrong reason.
-v_bundle=""
-if [ -f mcp-server/dist/server.js ]; then
-  v_bundle=$(grep -A1 '"apple-pim-mcp"' mcp-server/dist/server.js \
-    | sed -n 's/.*version:[[:space:]]*"\([0-9][^"]*\)".*/\1/p' | head -1)
+if [ ! -f mcp-server/dist/server.js ]; then
+  echo "error: mcp-server/dist/server.js is missing." >&2
+  echo "  It is a tracked, generated artifact and is what actually ships." >&2
+  echo "  Rebuild it: (cd mcp-server && npm run build)" >&2
+  exit 1
+fi
+v_bundle=$(grep -A1 '"apple-pim-mcp"' mcp-server/dist/server.js \
+  | sed -n 's/.*version:[[:space:]]*"\([0-9][^"]*\)".*/\1/p' | head -1)
+if [ -z "$v_bundle" ]; then
+  echo "error: could not read the version out of mcp-server/dist/server.js." >&2
+  exit 1
 fi
 
 printf "%-40s %s\n" "File" "Version"
@@ -53,14 +61,10 @@ printf "%-40s %s\n" ".claude-plugin/marketplace.json"   "$v_marketplace"
 printf "%-40s %s\n" "mcp-server/package.json"           "$v_mcp"
 printf "%-40s %s\n" "openclaw/package.json"             "$v_openclaw_pkg"
 printf "%-40s %s\n" "openclaw/openclaw.plugin.json"     "$v_openclaw_man"
-if [ -n "$v_bundle" ]; then
-  printf "%-40s %s\n" "mcp-server/dist/server.js (built)" "$v_bundle"
-else
-  printf "%-40s %s\n" "mcp-server/dist/server.js (built)" "(not built)"
-fi
+printf "%-40s %s\n" "mcp-server/dist/server.js (built)" "$v_bundle"
 
 all="$v_plugin $v_marketplace $v_mcp $v_openclaw_pkg $v_openclaw_man"
-[ -n "$v_bundle" ] && all="$all $v_bundle"
+all="$all $v_bundle"
 uniq=$(printf '%s\n' $all | sort -u | wc -l | tr -d ' ')
 
 if [ "$uniq" != "1" ]; then


### PR DESCRIPTION
Two problems that would each have silently undone the v3.17.0 signing work.

## 1. The tap would have reverted on the next release

`publish-homebrew.yml` still rewrote the formula to the **source tarball** on every tag. The formula in `omarshahine/homebrew-tap` now installs the signed prebuilt binaries ([1368afd](https://github.com/omarshahine/homebrew-tap/commit/1368afd)), so the next tag would have quietly reverted brew users to ad-hoc builds and the permission re-prompts would have come back.

It also can't run on tag push any more. The signed asset is produced by `release-signed-artifacts.yml`, which runs in parallel and takes minutes, and lands in a **draft** release whose assets aren't anonymously downloadable. A tag-triggered run would race it and, even after it, point the formula at a URL nobody can fetch.

Now triggered by `release: published` — the assets exist and are public by definition — and it fails loudly rather than pointing the formula at a missing asset.

## 2. Bundle version drift was invisible

`check-versions.sh` now compares the built `mcp-server/dist/server.js`, and CI runs it.

`bump-version.sh` writes the five JSON files first and rebuilds the bundle last. A failed rebuild leaves the artifact that actually ships at the previous version while every JSON path reads as correct. The CI version-consistency action compares JSON paths and structurally cannot see inside a JS bundle.

**This nearly shipped.** The v3.17.0 bump hit exactly this: `esbuild` and the root `mailparser`/`turndown` deps were missing, and the bundle stayed at 3.16.1 while all five manifests said 3.17.0. I caught it by hand.

Correcting something I said earlier in the session: `bump-version.sh` *does* exit non-zero. The problem isn't a false success, it's that the failure lands **after** the version files are written and nothing downstream noticed. It now checks build dependencies before touching any file — verified to leave the tree completely untouched on failure.

The bundle version is extracted anchored on the `"apple-pim-mcp"` package identity, because the bundle inlines its dependencies' `package.json` objects and `encoding-japanese`'s version appears first.

## Verified

- Homebrew formula tested by installing from a scratch tap: binaries kept `TeamIdentifier=N9DRSTM2U6` and an identifier-anchored designated requirement (not a cdhash), and `brew test` passed its signature assertions. Machine state restored afterwards.
- The `perl` url/sha256 replacements tested against the real new formula.
- Drift detection confirmed: a bump with a broken build now fails the check (exit 1).
- Preflight confirmed to leave the working tree untouched on failure.
- All 29 shell tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLUihyCxxoqvYr1EZhJVze