### PR TITLE
fix(helper): declare entitlements so TCC can prompt under hardened runtime

### DIFF
--- a/helper/PIMHelper.entitlements
+++ b/helper/PIMHelper.entitlements
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	Required under the hardened runtime, which notarization mandates.
+
+	The helper exists to be the TCC-responsible process for the Swift CLIs, so
+	it is the bundle macOS evaluates when they touch a protected resource. A
+	hardened-runtime binary without the matching entitlement is refused access
+	outright and NO consent dialog is shown, which leaves the user with nothing
+	to grant: the Contacts pane has no "+" button, and tccutil reset does not
+	help because the request never reaches a prompt.
+
+	That is exactly what shipped in v3.17.0 for Contacts (issue #159).
+	-->
+	<key>com.apple.security.personal-information.addressbook</key>
+	<true/>
+	<key>com.apple.security.personal-information.calendars</key>
+	<true/>
+	<!-- mail-cli drives Mail.app over JXA; reminder-cli/calendar-cli use EventKit. -->
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+</dict>
+</plist>

--- a/scripts/build-helper-app.sh
+++ b/scripts/build-helper-app.sh
@@ -51,7 +51,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ ! -f "$SRC_DIR/Info.plist" || ! -f "$SRC_DIR/pim-helper" || ! -f "$SRC_DIR/launcher.c" ]]; then
+if [[ ! -f "$SRC_DIR/Info.plist" || ! -f "$SRC_DIR/pim-helper" || ! -f "$SRC_DIR/launcher.c" \
+    || ! -f "$SRC_DIR/PIMHelper.entitlements" ]]; then
     echo "build-helper-app: missing helper sources at $SRC_DIR" >&2
     exit 1
 fi
@@ -62,6 +63,13 @@ fi
 # is a binary, so they cannot be compared with cmp.
 LAUNCHER_STAMP_REL="Contents/Resources/.launcher-source-sha256"
 launcher_source_hash() { shasum -a 256 "$SRC_DIR/launcher.c" | awk '{print $1}'; }
+
+# Same problem for the entitlements: they are baked into the signature, not
+# copied into the bundle, so nothing in the installed tree reflects a change to
+# them. Without this stamp an entitlements edit would be silently skipped by the
+# freshness check on every machine that already has a bundle installed.
+ENTITLEMENTS_STAMP_REL="Contents/Resources/.entitlements-source-sha256"
+entitlements_source_hash() { shasum -a 256 "$SRC_DIR/PIMHelper.entitlements" | awk '{print $1}'; }
 
 # True when the installed bundle's signature matches the requested identity.
 # Ad-hoc shows as `Signature=adhoc` (no Authority line); a certificate shows
@@ -85,6 +93,7 @@ installed_identity_matches() {
 if [[ "$FORCE" != true && -d "$APP_PATH" ]] \
     && cmp -s "$SRC_DIR/Info.plist" "$APP_PATH/Contents/Info.plist" \
     && cmp -s "$SRC_DIR/pim-helper" "$APP_PATH/Contents/Resources/pim-helper.sh" \
+    && [[ "$(cat "$APP_PATH/$ENTITLEMENTS_STAMP_REL" 2>/dev/null)" == "$(entitlements_source_hash)" ]] \
     && [[ "$(cat "$APP_PATH/$LAUNCHER_STAMP_REL" 2>/dev/null)" == "$(launcher_source_hash)" ]] \
     && codesign --verify "$APP_PATH" >/dev/null 2>&1 \
     && { [[ -z "${APPLE_PIM_SIGN_IDENTITY:-}" ]] || installed_identity_matches; }; then
@@ -144,6 +153,7 @@ chmod +x "$APP_PATH/Contents/MacOS/pim-helper"
 # Record which launcher source built this binary so the freshness check above
 # can detect launcher.c changes on a later run.
 launcher_source_hash > "$APP_PATH/$LAUNCHER_STAMP_REL"
+entitlements_source_hash > "$APP_PATH/$ENTITLEMENTS_STAMP_REL"
 
 # Sign the bundle. --force overwrites any prior signature; --deep walks
 # contents (the bundle is shallow but this future-proofs nested files).
@@ -157,8 +167,31 @@ launcher_source_hash > "$APP_PATH/$LAUNCHER_STAMP_REL"
 if [[ "$SIGN_IDENTITY" == "-" ]]; then
     codesign --force --deep --sign - "$APP_PATH" >/dev/null
 else
+    # --entitlements is not optional here. Notarization requires the hardened
+    # runtime, and a hardened-runtime bundle without the matching entitlement is
+    # denied protected resources with no consent dialog at all -- the user is
+    # left with nothing to grant. v3.17.0 shipped exactly that for Contacts
+    # (issue #159); codesign --verify, spctl and notarization all pass on the
+    # broken bundle, so nothing upstream catches it.
     codesign --force --deep --timestamp --options runtime \
+        --entitlements "$SRC_DIR/PIMHelper.entitlements" \
         --sign "$SIGN_IDENTITY" "$APP_PATH" >/dev/null
+
+    # Assert rather than trust: the failure this guards against is invisible to
+    # every other check in the pipeline, and only shows up as a user unable to
+    # grant Contacts weeks later.
+    if codesign -dvvv "$APP_PATH" 2>&1 | grep -qE '^CodeDirectory .*flags=0x[0-9a-f]+\([^)]*runtime'; then
+        for required in \
+            com.apple.security.personal-information.addressbook \
+            com.apple.security.personal-information.calendars \
+            com.apple.security.automation.apple-events; do
+            if ! codesign -d --entitlements - --xml "$APP_PATH" 2>/dev/null | grep -q "$required"; then
+                echo "build-helper-app: hardened runtime is set but $required is missing" >&2
+                echo "build-helper-app: TCC would deny that resource with no prompt; refusing to ship" >&2
+                exit 1
+            fi
+        done
+    fi
 fi
 
 # Register with Launch Services so `open -a` resolves the bundle id. Skipped

--- a/scripts/build-helper-app.sh
+++ b/scripts/build-helper-app.sh
@@ -119,13 +119,16 @@ mkdir -p "$(dirname "$APP_PATH")"
 
 # Clean any previous install. Use python unlink to tolerate File Provider
 # (OneDrive / iCloud) volumes that reject `trash` and `rm`.
-if [[ -e "$APP_PATH" ]]; then
+remove_app_path() {
+    [[ -e "$APP_PATH" ]] || return 0
     if command -v trash >/dev/null 2>&1; then
         trash "$APP_PATH" 2>/dev/null || rm -rf "$APP_PATH"
     else
         rm -rf "$APP_PATH"
     fi
-fi
+}
+
+remove_app_path
 
 mkdir -p "$APP_PATH/Contents/MacOS" "$APP_PATH/Contents/Resources"
 cp "$SRC_DIR/Info.plist" "$APP_PATH/Contents/Info.plist"
@@ -180,16 +183,47 @@ else
     # Assert rather than trust: the failure this guards against is invisible to
     # every other check in the pipeline, and only shows up as a user unable to
     # grant Contacts weeks later.
+    #
+    # A rejected bundle must never be left at $APP_PATH. The working helper was
+    # already removed and the source stamps already written, so an installed
+    # reject would satisfy the freshness check on the next run and be treated as
+    # current forever -- a permanently broken helper that no rebuild repairs.
+    # Removing it costs the user one rebuild; leaving it costs them Contacts.
+    reject_bundle() {
+        echo "build-helper-app: $1" >&2
+        echo "build-helper-app: TCC would deny that resource with no prompt; refusing to ship" >&2
+        remove_app_path
+        echo "build-helper-app: removed the rejected bundle at $APP_PATH; re-run after fixing" >&2
+        exit 1
+    }
+
     if codesign -dvvv "$APP_PATH" 2>&1 | grep -qE '^CodeDirectory .*flags=0x[0-9a-f]+\([^)]*runtime'; then
+        signed_entitlements="$(codesign -d --entitlements - --xml "$APP_PATH" 2>/dev/null)"
         for required in \
             com.apple.security.personal-information.addressbook \
             com.apple.security.personal-information.calendars \
             com.apple.security.automation.apple-events; do
-            if ! codesign -d --entitlements - --xml "$APP_PATH" 2>/dev/null | grep -q "$required"; then
-                echo "build-helper-app: hardened runtime is set but $required is missing" >&2
-                echo "build-helper-app: TCC would deny that resource with no prompt; refusing to ship" >&2
-                exit 1
-            fi
+            # Presence is not enough: a key present with <false/> reads as
+            # declared while granting nothing, so require the boolean value.
+            #
+            # plutil -extract is not usable here: it treats "." as a key-path
+            # separator, and every entitlement key is dotted, so it reports
+            # "No value at that key path" for all of them and would reject
+            # every valid bundle.
+            value="$(printf '%s' "$signed_entitlements" | python3 -c '
+import plistlib, sys
+key = sys.argv[1]
+try:
+    declared = plistlib.loads(sys.stdin.buffer.read())
+except Exception:
+    sys.exit(0)
+value = declared.get(key)
+if value is None:
+    sys.exit(0)
+print("true" if value is True else str(value))
+' "$required" 2>/dev/null || true)"
+            [[ -n "$value" ]] || reject_bundle "hardened runtime is set but $required is missing"
+            [[ "$value" == "true" ]] || reject_bundle "$required is present but set to '$value', not true"
         done
     fi
 fi


### PR DESCRIPTION
Fixes #159.

## Problem

The notarized `PIMHelper.app` in v3.17.0 **cannot obtain Contacts access**. It is denied immediately with no consent dialog, so a user has no way to grant it — the Contacts pane has no `+` button, and `tccutil reset` does not help because the request never reaches a prompt.

Notarization requires the hardened runtime, and under it a bundle must declare an entitlement for each protected resource it touches. `build-helper-app.sh` signs with `--options runtime` but no `--entitlements`, so the helper has none. Since the helper exists precisely to be the TCC-responsible process for the Swift CLIs, it is the bundle macOS evaluates — and the omission denies the CLIs.

## Confirmed by controlled experiment

Four bundles with fresh bundle ids so none inherited TCC history, all running the same signed `contacts-cli` from the v3.17.0 formula. Only the signing differed:

| Signature | Entitlements | Result |
|-----------|--------------|--------|
| ad-hoc | none | **prompts** |
| ad-hoc + `--options runtime` | none | **`Code=100` denied, no prompt** |
| ad-hoc + `--options runtime` | addressbook, calendars, apple-events | **prompts** |

The middle row reproduces the shipped failure exactly; the third is identical to it apart from the entitlements. So the hardened runtime is the trigger and the missing entitlement is the cause — not notarization, not the signature type, and not the CLIs.

The installed release helper matches the broken row:

```
CodeDirectory v=20500 flags=0x10000(runtime)
$ codesign -d --entitlements - ~/Applications/PIMHelper.app
(empty)
```

## Changes

**`helper/PIMHelper.entitlements`** — declares addressbook, calendars, and apple-events.

**Post-sign assertion.** This failure is invisible to `codesign --verify`, `spctl`, and notarization; all three pass on the broken bundle, and it surfaces only as a user who cannot grant Contacts. The build now refuses to produce a hardened bundle whose entitlements do not match.

**Entitlements freshness stamp.** Entitlements are baked into the signature rather than copied into the bundle, so nothing in an installed tree reflects a change to them. Without a stamp the freshness check would silently skip the rebuild on every machine that already has a helper installed — the same reason `launcher.c` has one.

## Verification

Ran the hardened-runtime branch with an ad-hoc identity (no Developer ID cert on the test machine — the `--entitlements` handling is the same code path):

- Produces `flags=0x10002(adhoc,runtime)` with all three entitlements present in the signature
- Negative test: removing `addressbook` from the plist makes the build refuse, naming the missing entitlement
- Freshness stamp written to the bundle

## Note on scope

Calendars and Reminders happen to work today on the unentitled bundle, so this is specific to Contacts rather than a general hardened-runtime break. They are declared here rather than relying on that continuing to hold. Happy to drop them if you would rather declare only what is demonstrably required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFhd1rcXuwUchP7o5bxcdM