### PR TITLE
chore: release v3.18.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "apple-pim",
       "source": "./",
       "description": "Native macOS integration for Calendar, Reminders, Contacts, and Mail using EventKit, Contacts, and JXA frameworks",
-      "version": "3.17.0",
+      "version": "3.18.0",
       "keywords": [
         "calendar",
         "reminders",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "description": "Native macOS integration for Calendar, Reminders, Contacts, and Mail using EventKit, Contacts, and JXA frameworks",
   "author": {
     "name": "Omar Shahine",

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -72087,7 +72087,7 @@ import { dirname as dirname2, join as join3 } from "path";
 // package.json
 var package_default = {
   name: "apple-pim-mcp",
-  version: "3.17.0",
+  version: "3.18.0",
   description: "MCP server for Apple PIM, a Personal Information Manager for Calendar, Reminders, Contacts, and Mail",
   type: "module",
   main: "dist/server.js",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim-mcp",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "description": "MCP server for Apple PIM, a Personal Information Manager for Calendar, Reminders, Contacts, and Mail",
   "type": "module",
   "main": "dist/server.js",

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -92,7 +92,7 @@
       }
     }
   },
-  "version": "3.17.0",
+  "version": "3.18.0",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-pim-cli",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "description": "OpenClaw plugin for macOS Calendar, Reminders, Contacts, and Mail. macOS-only; depends on four native Swift CLIs (calendar-cli, reminder-cli, contacts-cli, mail-cli) you build locally from source via ./setup.sh. The registry does not download or install binaries.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump only — all five sources plus the rebuilt MCP bundle, via `scripts/bump-version.sh 3.18.0`.

Minor rather than patch: the helper bundle is renamed, the installer grows a flag, and the signed release asset changes name.

## What ships

| PR | |
|---|---|
| #158 | `feat(helper)` TCC bundle renamed to **`Apple PIM Helper.app`**. macOS takes the name it shows in a permission prompt and in Privacy & Security from the bundle's *filename*, not `CFBundleDisplayName`, so the prompt read "PIMHelper". Existing installs migrate with `mv` — signature byte-identical, grants intact. The installer now also refuses to replace a certificate-signed bundle with an ad-hoc one (`--allow-adhoc-downgrade` overrides). |
| #160 | `fix(helper)` declare entitlements so TCC can prompt under the hardened runtime |
| #149 | `fix` Calendar reads work with write-only EventKit access |
| #157 | `fix` Homebrew points at the signed assets; bundle version drift is caught |

## Note for consumers

The signed helper asset is published as **`apple-pim-helper-<version>.zip`** (was `PIMHelper-<version>.zip`). Nothing in-repo consumes it — the Homebrew workflow only reads the CLI zip.

## Verification

- `scripts/check-versions.sh` — all six sources agree on `3.18.0`
- 104/104 Node tests pass
- Merged `main`'s installer run end-to-end before the bump: fresh install renames and resolves `kMDItemDisplayName = "Apple PIM Helper"`; a legacy Developer ID bundle renames with `Authority` and CDHash intact and the ad-hoc rebuild correctly refused

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zCWqGNMG1XNBkBSLQQN8G